### PR TITLE
Add support for multiple .lib or .dll files

### DIFF
--- a/robotpy_build/platforms.py
+++ b/robotpy_build/platforms.py
@@ -15,7 +15,7 @@ _platforms = {
     "linux-x86_64": WPILibMavenPlatform("linux", "x86-64", "lib", ".so"),
     # TODO: linuxraspbian
     "win32": WPILibMavenPlatform("windows", "x86", "", ".dll"),
-    "win-amd64": WPILibMavenPlatform("windows", "x86-64", "", ".dll"),
+    "win-amd64": WPILibMavenPlatform("windows", "x86-64", "", ".dll|.lib"),
     # TODO: need to filter this value
     "macosx-10.9-x86_64": WPILibMavenPlatform("osx", "x86-64", "lib", ".dylib"),
 }

--- a/robotpy_build/wrapper.py
+++ b/robotpy_build/wrapper.py
@@ -192,7 +192,7 @@ class Wrapper:
         if libnames:
             libext = self.cfg.libexts.get(self.platform.libext, self.platform.libext)
 
-            libnames = [f"{self.platform.libprefix}{lib}{libext}" for lib in libnames]
+            libnames = [f"{self.platform.libprefix}{lib}{libext_i}" for lib in libnames for libext_i in libext.split("|")]
 
             os.makedirs(libdir)
             to = {


### PR DESCRIPTION
Adds the ability to copy multiple file types over using a pipe as a extension separator.
Ex: `WPILibMavenPlatform("windows", "x86-64", "", ".dll|.lib")`

Removes the issue where the .lib files from the win-x32-64 artifacts would not be loaded and usable, while preserving functionality for any os that doesn't require multiple files.