### PR TITLE
Fix Windows Library Linking

### DIFF
--- a/robotpy_build/pyproject_configs.py
+++ b/robotpy_build/pyproject_configs.py
@@ -56,6 +56,10 @@ class WrapperConfig(BaseModel):
     # set to name. If empty list, libs will not be downloaded.
     libs: Optional[List[str]] = None
 
+    # Names of contained shared link only libraries (in loading order). If None,
+    # set to name. If empty list, link only libs will not be downloaded.
+    dlopenlibs: Optional[List[str]] = None
+
     # Name of artifact to download, if different than name
     artname: str = ""
 


### PR DESCRIPTION
`dll` files are required in windows libraries. However, `lib` files are only with some `dll`s.

This adds optional link extensions and adds an `optional` parameter in the download functions.

This patch allows halsim to build on Windows.