### PR TITLE
Config based optional link files

### DIFF
--- a/robotpy_build/pyproject_configs.py
+++ b/robotpy_build/pyproject_configs.py
@@ -72,6 +72,9 @@ class WrapperConfig(BaseModel):
     # Compile time extensions map
     linkexts: Dict[str, str] = {}
 
+    # Whether a linking file is required (should only be used for halsim)
+    link_required: bool = True
+
     #
     # Wrapper generation settings
     #

--- a/robotpy_build/wrapper.py
+++ b/robotpy_build/wrapper.py
@@ -191,7 +191,9 @@ class Wrapper:
 
         if libnames:
             libext = self.cfg.libexts.get(self.platform.libext, self.platform.libext)
-            linkext = self.cfg.linkexts.get(self.platform.linkext, self.platform.linkext)
+            linkext = libext
+            if self.cfg.link_required:
+                linkext = self.cfg.linkexts.get(self.platform.linkext, self.platform.linkext)
 
             libnames_full = [f"{self.platform.libprefix}{lib}{libext}" for lib in libnames]
             if libext != linkext:


### PR DESCRIPTION
Adds the link_required property (defaults to true) to the pyproject.toml so that halsim-gui doesn't break when building on windows. The config for halsim-gui just needs to be set to false and it all works properly.