### PR TITLE
macos support - library linking

### DIFF
--- a/docs/macos.md
+++ b/docs/macos.md
@@ -70,9 +70,12 @@ need their paths updated.
 
 ### Relink Tool
 
-If your package is built in developer mode, then other package may fail to find/link to your package's libraries. You will need to relink the libraries of dependent packages.
+If your package is built in developer mode, then other package may fail to
+find/link to your package's libraries. You will need to relink the libraries of
+dependent packages.
 
-To relink the libraries of dependent packages, rather than rebuild those packages, you can use the relink-libraries tool.
+To relink the libraries of dependent packages, rather than rebuild those
+packages, you can use the relink-libraries tool.
 
 ```bash
 python -m robotpy_build relink-libraries "libraries" "dependents"
@@ -80,7 +83,8 @@ python -m robotpy_build relink-libraries "libraries" "dependents"
 
 `"libraries"` is the path to the folder containing `*.dylib` files.
 
-`"dependents"` is the path to the folder containing files that need to be fixed (have their dependecies relinked).
+`"dependents"` is the path to the folder containing files that need to be fixed
+(have their dependecies relinked).
 
 For example,
 ```bash
@@ -90,6 +94,34 @@ python -m robotpy_build relink-libraries ./robotpy-wpiutil ./pyntcore
 2. finds all dependencies for all (`*.so` and `*.dylib`) files in `./pyntcore`
 3. Relinks dependencies to libraries
 
-Note: This tool finds libraries and dependencies recursively. You do not need to specify very-specific paths (the above example does not either). However, the shallower the path, the longer the runtime.
+Note: This tool finds libraries and dependencies recursively. You do not need
+to specify very-specific paths (the above example does not either). However,
+the shallower the path, the longer the runtime.
 
-Subnote: If your library/dependency path contain multiple venvs, undesired libraries may be relinked.
+Subnote: If your library/dependency path contain multiple venvs, undesired
+libraries may be relinked.
+
+### Easy Workflow
+
+Understandably, you may not want to spend time relinking sepcific libraries as
+you are working. This is a suggested workflow to minimize manual relinking
+efforts.
+
+Setup your workspace as (example):
+
+```
+workspace/
+├── venv/               <- Your virtualenv
+├── robotpy-build/
+├── robotpy-wpiutil/
+└── robotpy-pyntcore/   <- Ex. A package you are developing
+```
+
+Then, to relink libraries after a rebuild, run:
+```bash
+workspace/ $ python -m robotpy_build relink-libraries . .
+```
+
+This will fix all dependencies.
+
+Note: The runtime of this workflow is higher than specifying more specific paths.

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -10,7 +10,7 @@ For now, look at https://github.com/robotpy/pyntcore as an example.
 Modify pyproject.toml
 ---------------------
 
-### Existing
+### Prerequisite
 
 Libraries downloaded when building are defined by `libs`.
 ```toml
@@ -46,7 +46,7 @@ Absolute paths can also be sepcified. Absolute paths must be bookended by an
 `@`. For example, `"@/Users/FakeUser/Desktop/libfake.dylib@"` resolves as is
 to `"/Users/FakeUser/Desktop/libfake.dylib/"`.
 
-Note: Do not treat a relative path as an absolute path. In most cases, this
+Note: Do not treat a relative path as an absolute path. In most cases, it
 will fail.
 
 Automatic Library Detection
@@ -58,10 +58,11 @@ an internal library is defined, it will override the automatically found path.
 
 Building in Developer Mode
 --------------------------
+### Path Resolution
 
 When building in developer mode (`python setup.py develop` or `pip install -e`),
 automatic library detection will fail. Paths to all libraries need to be defined.
-Furthmore, resolution of relative paths may also fail. For guaranteed path
+Furthermore, resolution of relative paths may also fail. For guaranteed path
 resolution, use absolute paths when building in developer mode.
 
 Note: All packages depending on a library provided by your package will also

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -68,3 +68,28 @@ resolution, use absolute paths when building in developer mode.
 Note: All packages depending on a library provided by your package will also
 need their paths updated.
 
+### Relink Tool
+
+If your package is built in developer mode, then other package may fail to find/link to your package's libraries. You will need to relink the libraries of dependent packages.
+
+To relink the libraries of dependent packages, rather than rebuild those packages, you can use the relink-libraries tool.
+
+```bash
+python -m robotpy_build relink-libraries "libraries" "dependents"
+```
+
+`"libraries"` is the path to the folder containing `*.dylib` files.
+
+`"dependents"` is the path to the folder containing files that need to be fixed (have their dependecies relinked).
+
+For example,
+```bash
+python -m robotpy_build relink-libraries ./robotpy-wpiutil ./pyntcore
+```
+1. finds all libraries (`*.dylib`) in `./robotpy-wpiutil`
+2. finds all dependencies for all (`*.so` and `*.dylib`) files in `./pyntcore`
+3. Relinks dependencies to libraries
+
+Note: This tool finds libraries and dependencies recursively. You do not need to specify very-specific paths (the above example does not either). However, the shallower the path, the longer the runtime.
+
+Subnote: If your library/dependency path contain multiple venvs, undesired libraries may be relinked.

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -1,0 +1,69 @@
+Building on macOS
+=================
+
+macOS handles library files differently than Windows or Linux. macOS will not
+automatically find and link libraries at runtime. Rather, libraries need to be
+linked beforehand.
+
+For now, look at https://github.com/robotpy/pyntcore as an example.
+
+Modify pyproject.toml
+---------------------
+
+### Existing
+
+Libraries downloaded when building are defined by `libs`.
+```toml
+libs = ["ntcore"]
+```
+
+External libraries required are defined by `depends`.
+```toml
+depends = ["wpiutil"]
+```
+
+### Modifications
+
+To assist macOS in finding libraries, add a
+`tool.robotpy-build.macos_lib_locations` sections. The keys and values here
+define the paths to libraries.
+
+```toml
+[tool.robotpy-build.macos_lib_locations]
+"libwpiutil.dylib" = "wpiutil/lib/libwpiutil.dylib"
+```
+
+#### Relative Paths
+
+This path is relative to to the parent of the package directory. Usually, the
+parent of the package directory is your site-packages folder. In the example,
+(on my system) `"wpiutil/lib/libwpiutil.dylib"` resolves to
+`".../site-packages/wpiutil/lib/libwpiutil.dylib"`.
+
+#### Absolute Paths
+
+Absolute paths can also be sepcified. Absolute paths must be bookended by an
+`@`. For example, `"@/Users/FakeUser/Desktop/libfake.dylib@"` resolves as is
+to `"/Users/FakeUser/Desktop/libfake.dylib/"`.
+
+Note: Do not treat a relative path as an absolute path. In most cases, this
+will fail.
+
+Automatic Library Detection
+---------------------------
+
+Paths to internal libraries (usually defined in `libs`) are automatically
+detected. Paths to these libraries do not have to be defined. If a path to
+an internal library is defined, it will override the automatically found path.
+
+Building in Developer Mode
+--------------------------
+
+When building in developer mode (`python setup.py develop` or `pip install -e`),
+automatic library detection will fail. Paths to all libraries need to be defined.
+Furthmore, resolution of relative paths may also fail. For guaranteed path
+resolution, use absolute paths when building in developer mode.
+
+Note: All packages depending on a library provided by your package will also
+need their paths updated.
+

--- a/robotpy_build/command/build_ext.py
+++ b/robotpy_build/command/build_ext.py
@@ -77,9 +77,15 @@ class BuildExt(build_ext):
         # Fix Libraries on macOS
         # Uses @loader_path, is compatible with macOS >= 10.4
         platform = get_platform()
-        if get_platform().os == 'osx' and self.macos_lib_locations is not None:
+        if get_platform().os == 'osx':
             from ..relink_libs import redirect_links, get_build_path
-            redirect_links(get_build_path(self.extensions[0].name, self.build_lib), self.macos_lib_locations)
+            redirect_links(
+                get_build_path(
+                    self.extensions[0].name,
+                    self.build_lib
+                ),
+                self.macos_lib_locations
+            )
 
     def run(self):
 

--- a/robotpy_build/command/build_ext.py
+++ b/robotpy_build/command/build_ext.py
@@ -73,6 +73,13 @@ class BuildExt(build_ext):
         # self._gather_global_includes()
 
         build_ext.build_extensions(self)
+        
+        # Fix Libraries on macOS
+        # Uses @loader_path, is compatible with macOS >= 10.4
+        platform = get_platform()
+        if get_platform().os == 'osx' and self.macos_lib_locations is not None:
+            from ..relink_libs import redirect_links, get_build_path
+            redirect_links(get_build_path(self.extensions[0].name, self.build_lib), self.macos_lib_locations)
 
     def run(self):
 

--- a/robotpy_build/command/build_ext.py
+++ b/robotpy_build/command/build_ext.py
@@ -77,7 +77,7 @@ class BuildExt(build_ext):
         # Fix Libraries on macOS
         # Uses @loader_path, is compatible with macOS >= 10.4
         platform = get_platform()
-        if get_platform().os == 'osx':
+        if platform.os == 'osx':
             from ..relink_libs import redirect_links, get_build_path
             redirect_links(
                 get_build_path(

--- a/robotpy_build/platforms.py
+++ b/robotpy_build/platforms.py
@@ -1,7 +1,7 @@
 from distutils.util import get_platform as _get_platform
 from dataclasses import dataclass, field
 from typing import List, Tuple, Union
-from re import match
+import re
 
 
 # wpilib platforms at https://github.com/wpilibsuite/native-utils/blob/master/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
@@ -53,7 +53,7 @@ def get_platform() -> WPILibMavenPlatform:
     pyplatform = _get_platform()
 
     # Check for 64 bit x86 macOS (version agnostic)
-    if match(r'macosx.*x86_64', pyplatform):
+    if re.fullmatch(r'macosx-.*-x86_64', pyplatform):
         pyplatform = 'osx'
 
     try:

--- a/robotpy_build/platforms.py
+++ b/robotpy_build/platforms.py
@@ -36,8 +36,7 @@ _platforms = {
     # TODO: linuxraspbian
     "win32": WPILibMavenPlatform("x86", "windows", "", ".dll", ".lib"),
     "win-amd64": WPILibMavenPlatform(X86_64, "windows", "", ".dll", ".lib"),
-    # TODO: need to filter this value
-    "macosx-10.9-x86_64": WPILibMavenPlatform(X86_64, "osx", libext=".dylib"),
+    "osx": WPILibMavenPlatform(X86_64, "osx", libext=".dylib")
 }
 
 
@@ -51,6 +50,12 @@ def get_platform() -> WPILibMavenPlatform:
     #       be useful to note for the future.
 
     pyplatform = _get_platform()
+
+    # Check for 64 bit macOS (version agnostic)
+    if 'osx' in pyplatform and '64' in pyplatform:
+        # Note: Apple has renamed their OS to macOS.
+        pyplatform  = 'osx'
+
     try:
         return _platforms[pyplatform]
     except KeyError:

--- a/robotpy_build/platforms.py
+++ b/robotpy_build/platforms.py
@@ -1,6 +1,7 @@
 from distutils.util import get_platform as _get_platform
 from dataclasses import dataclass, field
 from typing import List, Tuple, Union
+from re import match
 
 
 # wpilib platforms at https://github.com/wpilibsuite/native-utils/blob/master/src/main/java/edu/wpi/first/nativeutils/WPINativeUtilsExtension.java
@@ -51,10 +52,9 @@ def get_platform() -> WPILibMavenPlatform:
 
     pyplatform = _get_platform()
 
-    # Check for 64 bit macOS (version agnostic)
-    if 'osx' in pyplatform and '64' in pyplatform:
-        # Note: Apple has renamed their OS to macOS.
-        pyplatform  = 'osx'
+    # Check for 64 bit x86 macOS (version agnostic)
+    if match(r'macosx.*x86_64', pyplatform):
+        pyplatform = 'osx'
 
     try:
         return _platforms[pyplatform]

--- a/robotpy_build/pyproject_configs.py
+++ b/robotpy_build/pyproject_configs.py
@@ -148,3 +148,6 @@ class RobotpyBuildConfig(BaseModel):
 
     # [tool.robotpy-build.wrappers."XXX"]
     wrappers: Dict[str, WrapperConfig] = {}
+
+    # [tool.robotpy-build.macos_lib_locations]
+    macos_lib_locations: Dict[str, str] = {}

--- a/robotpy_build/pyproject_configs.py
+++ b/robotpy_build/pyproject_configs.py
@@ -150,4 +150,4 @@ class RobotpyBuildConfig(BaseModel):
     wrappers: Dict[str, WrapperConfig] = {}
 
     # [tool.robotpy-build.macos_lib_locations]
-    macos_lib_locations: Dict[str, str] = {}
+    macos_lib_locations: Optional[Dict[str, str]] = {}

--- a/robotpy_build/relink_libs.py
+++ b/robotpy_build/relink_libs.py
@@ -1,0 +1,156 @@
+from delocate.delocating import filter_system_libs
+from delocate.libsana import tree_libs
+from delocate.tools import set_install_name as _set_install_name
+
+from os import path
+
+def get_build_dependencies(build_path: str) -> list:
+    """Finds the dependecies of all library files under build_path (recursive).
+
+    :param build_path: Path to the package in the build directory (".../build/package/")
+    :type build_path: str
+
+    :return: dependencies in the form: [ ('file' : [files it wants]) ]
+    :rtype: list
+    """
+
+    # import code
+    # code.interact(local=dict(globals(), **locals()))
+
+    #Build Tree of all dependencies
+    build_deps = tree_libs(build_path)
+
+    #Discard System Dependencies
+    our_build_deps = []
+    for key in build_deps:
+        if filter_system_libs(key):
+            for k, v in build_deps[key].items():
+                our_build_deps.append( [k,v] )
+
+    #Make sure 'files it wants' is a list
+    for elem in our_build_deps:
+        if isinstance( elem[1], str ):
+            elem[1] = [elem[1]]
+    
+    return our_build_deps
+
+
+def get_build_path(ext_fullname: str, build_lib: str) -> str:
+    """Finds the path to the build directory
+
+    :param ext_fullname: Ex. 'wpiutil._wpiutil'
+    :type ext_fullname: str
+
+    :param build_lib: Ex. '.../build'
+    :type build_lib: str
+
+    :return: Build Path -> Ex. '.../build/wpiutil'
+    :rtype: str
+    """
+    # Ex. ext_fullname = 'wpiutil._wpiutil
+    # Ex. build_lib = '.../build'
+
+    modpath = ext_fullname.split('.')
+    package = '.'.join(modpath[:-1])
+    build_path = path.join(build_lib, package) # Ex. ".../build/wpiutil"
+
+    return build_path 
+
+def set_install_name(file: str, old_install_name: str, new_install_name: str):
+    """Change the install name for a library
+
+    :param file: path to a executable/library file
+    :type file: str
+
+    :param old_install_name: current path to dependency
+    :type old_install_name: str
+
+    :param new_install_name: new path to dependency
+    :type old_install_name: str
+    """
+
+    # This function just calls delocate's set_install_name which uses install_name_tool.
+    # This function exists in case we want to change the implementation.
+
+    _set_install_name(file, old_install_name, new_install_name)
+    print(file, ':', old_install_name, '->', new_install_name)
+
+
+
+def redirect_links(build_path: str, path_map: dict, dependencies: list = None, approximate: bool = True, supress_errors = False):
+    """Redirects links to libraries
+
+    :param build_path: Build Path (into package) -> Ex. '.../build/wpiutil'
+    :type build_path: str
+
+    :param path_map:
+        A mapping of library names to library paths (relative paths)
+        If a path is bookended by '@', then it is treated as an absolute path.
+        Ex. 'lib/libwpiutil.dylib' -> '.../wpilib/../wpilib/lib/libwpiutil.dylib'
+        Ex. '@lib/libwpiutil.dylib@' -> 'lib/libwpiutil.dylib'
+    :type path_map: dict
+
+    :param dependencies:
+        dependencies in the form: [ ('file' : [files it wants]) ],
+        If None, it will generate them from build_path,
+        Defaults to None
+    :type dependencies: list, optional
+
+    :param approximate:
+        If True, it will match the basename (Ex. 'libwpiutil.dylib') of library
+        paths instead of full library paths. This allows for this function to
+        be called multiple times on the same library (aslong as the basename
+        doesn't change).
+        Defaults to True
+
+    :type approximate: bool, optional
+
+    :param suppress_errors:
+        Optional, Defaults to False
+    :type suppress_errors: bool
+
+    :raises: not if you're good
+
+    """
+
+    if dependencies is None:
+        dependencies = get_build_dependencies(build_path)
+        print(dependencies)
+
+    for dependency in dependencies:
+        library_file_path = dependency[0]
+        desired_files = dependency[1]
+        
+        rel_path = path.relpath(build_path, library_file_path) #Relative path to site-packages (essentially)
+
+        for desired_file in desired_files:
+            path_to_desired_file = path_map.get(
+                path.basename(desired_file) if approximate else desired_file,
+                None
+            )
+
+            if path_to_desired_file is None:
+                if supress_errors: continue
+                raise KeyError('Path to `' + path_to_desired_file + '` not found')
+
+            if len(path_to_desired_file) == 0:
+                if supress_errors: continue
+                raise ValueError('Invalid Path of 0 length')
+
+            # Treat as absolute path if bookended by '@'
+            if path_to_desired_file[0] == '@' and path_to_desired_file[-1] == '@':
+                if len(path_to_desired_file) < 3:
+                    if supress_errors: continue
+                    raise ValueError('Invalid Absolute Path of 0 length')
+                path_to_desired_file = path_to_desired_file[ 1: -1]
+                set_install_name(
+                    library_file_path,
+                    desired_file,
+                    path_to_desired_file
+                )
+            else:
+                set_install_name(
+                    library_file_path,
+                    desired_file,
+                    path.join('@loader_path', rel_path, path_to_desired_file)
+                )

--- a/robotpy_build/relink_libs.py
+++ b/robotpy_build/relink_libs.py
@@ -107,7 +107,7 @@ def set_install_name(file: str, old_install_name: str, new_install_name: str):
 
 
 
-def redirect_links(build_path: str, path_map: dict, dependencies: list = None, approximate: bool = True, supress_errors = False):
+def redirect_links(build_path: str, path_map: dict, dependencies: list = None, approximate: bool = True, auto_detect: bool = True, supress_errors = False):
     """Redirects links to libraries
 
     :param build_path: Build Path (into package) -> Ex. '.../build/wpiutil'
@@ -135,6 +135,12 @@ def redirect_links(build_path: str, path_map: dict, dependencies: list = None, a
 
     :type approximate: bool, optional
 
+    :param auto_detect:
+        If True, attempt to automatic find library files.
+        Defaults to True
+    
+    :type auto_detect: bool, optional
+
     :param suppress_errors:
         Optional, Defaults to False
     :type suppress_errors: bool
@@ -143,7 +149,7 @@ def redirect_links(build_path: str, path_map: dict, dependencies: list = None, a
 
     """
 
-    auto_detected_dependencies = find_all_libs(build_path)
+    auto_detected_dependencies = find_all_libs(build_path) if auto_detect else {}
     print(auto_detected_dependencies)
 
     if dependencies is None:

--- a/robotpy_build/relink_libs.py
+++ b/robotpy_build/relink_libs.py
@@ -143,18 +143,12 @@ def redirect_links(build_path: str, path_map: dict, dependencies: list = None, a
 
     """
 
-    # import code
-    # code.interact(local=dict(globals(), **locals()))
-
-    auto_detected_dependencies = find_libs(build_path)
-
-    # list_files(build_path)
-
-    # print(auto_detected_dependencies)
+    auto_detected_dependencies = find_all_libs(build_path)
+    print(auto_detected_dependencies)
 
     if dependencies is None:
         dependencies = get_build_dependencies(build_path)
-        # print(dependencies)
+        print(dependencies)
 
     for dependency in dependencies:
         library_file_path = dependency[0]
@@ -167,11 +161,14 @@ def redirect_links(build_path: str, path_map: dict, dependencies: list = None, a
 
             path_to_desired_file = path_map.get(df_search_name, None)
             if path_to_desired_file is None:
-                abs_path_to_df = auto_detected_dependencies.get(df_search_name, None)
+                abs_path_to_df = auto_detected_dependencies.get(
+                    path.basename(df_search_name),
+                    None
+                )
 
                 if abs_path_to_df is None:
                     if supress_errors: continue
-                    raise KeyError('Path to `' + path_to_desired_file + '` not found')
+                    raise KeyError('Path to `' + desired_file + '` not found')
 
                 path_to_desired_file = path.relpath(
                     abs_path_to_df, 
@@ -184,7 +181,7 @@ def redirect_links(build_path: str, path_map: dict, dependencies: list = None, a
 
             if path_to_desired_file is None:
                 if supress_errors: continue
-                raise KeyError('Path to `' + path_to_desired_file + '` not found')
+                raise KeyError('Path to `' + desired_file + '` not found')
 
             if len(path_to_desired_file) == 0:
                 if supress_errors: continue

--- a/robotpy_build/setup.py
+++ b/robotpy_build/setup.py
@@ -98,7 +98,7 @@ class Setup:
             self.setup_kwargs["cmdclass"]["bdist_wheel"] = bdist_wheel
         for cls in self.setup_kwargs["cmdclass"].values():
             cls.wrappers = self.wrappers
-            cls.macos_lib_locations = self.project_dict.get("macos_lib_locations", None)
+            cls.macos_lib_locations = self.project_dict.get("macos_lib_locations", {})
 
     def _generate_long_description(self):
         readme_rst = join(self.root, "README.rst")

--- a/robotpy_build/setup.py
+++ b/robotpy_build/setup.py
@@ -98,6 +98,7 @@ class Setup:
             self.setup_kwargs["cmdclass"]["bdist_wheel"] = bdist_wheel
         for cls in self.setup_kwargs["cmdclass"].values():
             cls.wrappers = self.wrappers
+            cls.macos_lib_locations = self.project_dict.get("macos_lib_locations", None)
 
     def _generate_long_description(self):
         readme_rst = join(self.root, "README.rst")

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,6 +30,7 @@ install_requires =
     toposort
     pyyaml >= 5.1
     dataclasses; python_version < '3.7'
+    delocate; platform_system == 'Darwin'
 setup_requires =
     setuptools_scm
 python_requires = >=3.6


### PR DESCRIPTION
Not fully tested.

Implementations:
Finds all library/executables in a build and analyzes the dependency tree for non-system dependencies and relinks them.

Usage:
In pyproject.toml for a project, under [tool.robotpy-build.macos_lib_locations], add mappings from library names to library locations. These can be relative (from the parent directory the package (essentially site-packages)) or absolute (bookended by @'s).
