### PR TITLE
Fix Docstrings on Windows

### DIFF
--- a/robotpy_build/templates/pybind11.cpp.j2
+++ b/robotpy_build/templates/pybind11.cpp.j2
@@ -262,7 +262,7 @@ py::enum_<{{ enum.x_namespace }}{{ enum.name }}>({{ scope }}, "{{ enum.x_name }}
     {%- endif -%}
     , {{ name }});
   
-  {{ doc(cls, varname + '.doc() =', ';') }}
+  {{ doc(cls, varname + '.doc() = py::str(PyUnicode_DecodeLocale(', ', NULL));') }}
   
   {# define class enums in case they are used as default args #}
   {% for enum in cls.enums.public %}


### PR DESCRIPTION
- Google tells me Windows uses UTF16-LE (little endian), not UTF-8 by default.
- Powershell says its text encoding is iso-8859-1 / Western European / Windows-1252

Hopefully this works on non-windows.