### PR TITLE
Add helpful error if a user tries to install an rpy package on an Unsupported Platform

### DIFF
--- a/robotpy_build/pyproject_configs.py
+++ b/robotpy_build/pyproject_configs.py
@@ -177,6 +177,9 @@ class RobotpyBuildConfig(BaseModel):
     # package to store version information in
     base_package: str
 
+    # platforms that are not supported
+    unsupported_platforms: List[Dict[str, str]] = []
+
     #
     # Everything below here are separate sections
     #

--- a/robotpy_build/pyproject_configs.py
+++ b/robotpy_build/pyproject_configs.py
@@ -178,7 +178,7 @@ class RobotpyBuildConfig(BaseModel):
     base_package: str
 
     # platforms that are not supported
-    unsupported_platforms: List[Dict[str, str]] = []
+    supported_platforms: List[Dict[str, str]] = []
 
     #
     # Everything below here are separate sections

--- a/robotpy_build/pyproject_configs.py
+++ b/robotpy_build/pyproject_configs.py
@@ -178,7 +178,7 @@ class RobotpyBuildConfig(BaseModel):
     base_package: str
 
     # platforms that are not supported
-    supported_platforms: List[Dict[str, str]] = []
+    supported_platforms: List[Dict[str, str]] = [{}]
 
     #
     # Everything below here are separate sections

--- a/robotpy_build/pyproject_configs.py
+++ b/robotpy_build/pyproject_configs.py
@@ -177,7 +177,7 @@ class RobotpyBuildConfig(BaseModel):
     # package to store version information in
     base_package: str
 
-    # platforms that are not supported
+    # platforms that are supported
     supported_platforms: List[Dict[str, str]] = [{}]
 
     #

--- a/robotpy_build/setup.py
+++ b/robotpy_build/setup.py
@@ -166,6 +166,7 @@ class Setup:
         # assemble all the pieces and make it work
         _setup(**self.setup_kwargs)
 
+
 def setup():
     s = Setup()
     s.prepare()

--- a/robotpy_build/setup.py
+++ b/robotpy_build/setup.py
@@ -4,7 +4,6 @@ from setuptools import find_packages, setup as _setup
 from setuptools import Extension
 from setuptools_scm import get_version
 import toml
-import dataclasses
 
 try:
     from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
@@ -165,45 +164,7 @@ class Setup:
 
     def run(self):
         # assemble all the pieces and make it work
-
-        # Check for unsupported platforms
-        platform_dict = dataclasses.asdict(self.platform)
-
-        os = platform_dict["os"]
-        arch = platform_dict["arch"]
-
-        is_os_supported = False
-        is_arch_supported = False
-
-        for supp_plat in self.project.supported_platforms:
-            supp_os = supp_plat.get("os", None)
-            supp_arch = supp_plat.get("arch", None)
-
-            if supp_os is None or supp_os == os:
-                is_os_supported = True
-                if supp_arch is None or supp_arch == arch:
-                    is_arch_supported = True
-
-        if not (is_os_supported and is_arch_supported):
-            if arch == "x86":
-                arch = "32-bit"
-            elif arch == "x86-64":
-                arch = "64-bit"
-
-            if os == "osx":
-                os = "macOS"
-
-            if not is_os_supported:
-                arch = ""
-
-            msg_plat = "{}{}{}".format(arch, " " if arch != "" else "", os)
-
-            err_msg = "{} is not supported on {}!".format(self.pypi_package, msg_plat)
-
-            raise OSError(err_msg)
-
         _setup(**self.setup_kwargs)
-
 
 def setup():
     s = Setup()

--- a/robotpy_build/setup.py
+++ b/robotpy_build/setup.py
@@ -196,13 +196,9 @@ class Setup:
             if not is_os_supported:
                 arch = ""
 
-            msg_plat = "{}{}{}".format(
-                arch, " " if arch != "" else "", os
-            )
+            msg_plat = "{}{}{}".format(arch, " " if arch != "" else "", os)
 
-            err_msg = "{} is not supported on {}!".format(
-                self.pypi_package, msg_plat
-            )
+            err_msg = "{} is not supported on {}!".format(self.pypi_package, msg_plat)
 
             raise OSError(err_msg)
 

--- a/robotpy_build/setup.py
+++ b/robotpy_build/setup.py
@@ -169,41 +169,42 @@ class Setup:
         # Check for unsupported platforms
         platform_dict = dataclasses.asdict(self.platform)
 
-        for un_pl in self.project.unsupported_platforms:
-            bad_platform = True
-            for k, v in un_pl.items():
-                try:
-                    platform_dict_val = platform_dict[k]
-                except:
-                    raise ValueError("Invalid unsupported configuration.")
-                if platform_dict_val != v:
-                    bad_platform = False
+        os = platform_dict["os"]
+        arch = platform_dict["arch"]
 
-            if bad_platform:
+        is_os_supported = False
+        is_arch_supported = False
 
-                bad_arch = un_pl.get("arch", "")
-                bad_os = un_pl.get("os", "versions of Python")
+        for supp_plat in self.project.supported_platforms:
+            supp_os = supp_plat.get("os", None)
+            supp_arch = supp_plat.get("arch", None)
 
-                msg_arch = ""
-                if bad_arch == "x86":
-                    msg_arch = "32-bit"
-                elif bad_arch == "x86-64":
-                    msg_arch = "64-bit"
-                else:
-                    msg_arch = bad_arch
+            if supp_os is None or supp_os == os:
+                is_os_supported = True
+                if supp_arch is None or supp_arch == arch:
+                    is_arch_supported = True
 
-                if bad_os == "osx":
-                    bad_os = "macOS"
+        if not (is_os_supported and is_arch_supported):
+            if arch == "x86":
+                arch = "32-bit"
+            elif arch == "x86-64":
+                arch = "64-bit"
 
-                msg_plat = "{}{}{}".format(
-                    msg_arch, " " if msg_arch != "" else "", bad_os,
-                )
+            if os == "osx":
+                os = "macOS"
 
-                err_msg = "{} is not supported on {}!".format(
-                    self.pypi_package, msg_plat
-                )
+            if not is_os_supported:
+                arch = ""
 
-                raise OSError(err_msg)
+            msg_plat = "{}{}{}".format(
+                arch, " " if arch != "" else "", os
+            )
+
+            err_msg = "{} is not supported on {}!".format(
+                self.pypi_package, msg_plat
+            )
+
+            raise OSError(err_msg)
 
         _setup(**self.setup_kwargs)
 

--- a/robotpy_build/setup.py
+++ b/robotpy_build/setup.py
@@ -178,7 +178,7 @@ class Setup:
                     raise ValueError("Invalid unsupported configuration.")
                 if platform_dict_val != v:
                     bad_platform = False
-            
+
             if bad_platform:
 
                 bad_arch = un_pl.get("arch", "")
@@ -196,14 +196,14 @@ class Setup:
                     bad_os = "macOS"
 
                 msg_plat = "{}{}{}".format(
-                    msg_arch,
-                    " " if msg_arch != "" else "",
-                    bad_os,
+                    msg_arch, " " if msg_arch != "" else "", bad_os,
                 )
 
-                err_msg = "{} is not supported on {}!".format(self.pypi_package, msg_plat)
+                err_msg = "{} is not supported on {}!".format(
+                    self.pypi_package, msg_plat
+                )
 
-                raise OSError(err_msg)       
+                raise OSError(err_msg)
 
         _setup(**self.setup_kwargs)
 

--- a/robotpy_build/wrapper.py
+++ b/robotpy_build/wrapper.py
@@ -138,6 +138,7 @@ class Wrapper:
         try:
             download_maven(self.cfg.maven_lib_download, classifier, dst, cache)
         except HTTPError as e:
+            # Check for a 404 error and raise an error if the platform isn't supported.
             if e.code != 404:
                 raise e
             else:

--- a/robotpy_build/wrapper.py
+++ b/robotpy_build/wrapper.py
@@ -172,7 +172,9 @@ class Wrapper:
 
                     msg_plat = "{}{}{}".format(arch, " " if arch != "" else "", os)
 
-                    err_msg = "{} is not supported on {}!".format(self.pypi_package, msg_plat)
+                    err_msg = "{} is not supported on {}!".format(
+                        self.pypi_package, msg_plat
+                    )
 
                     raise OSError(err_msg)
                 raise e

--- a/robotpy_build/wrapper.py
+++ b/robotpy_build/wrapper.py
@@ -26,6 +26,9 @@ import yaml
 from header2whatever.config import Config
 from header2whatever.parse import ConfigProcessor
 
+from urllib.error import HTTPError
+import dataclasses
+
 from setuptools import Extension
 
 from .devcfg import get_dev_config
@@ -111,6 +114,9 @@ class Wrapper:
             # Add self to extension so that build_ext can query it on OSX
             self.extension.rpybuild_wrapper = self
 
+            # Used if the maven download fails
+            self.supported_platforms = setup.project.supported_platforms
+
         if self.cfg.generate and not self.cfg.generation_data:
             raise ValueError(
                 "generation_data must be specified when generate is specified"
@@ -129,7 +135,47 @@ class Wrapper:
         self.dev_config = get_dev_config(self.name)
 
     def _extract_zip_to(self, classifier, dst, cache):
-        download_maven(self.cfg.maven_lib_download, classifier, dst, cache)
+        try:
+            download_maven(self.cfg.maven_lib_download, classifier, dst, cache)
+        except HTTPError as e:
+            if e.code != 404:
+                raise e
+            else:
+                platform_dict = dataclasses.asdict(self.platform)
+
+                os = platform_dict["os"]
+                arch = platform_dict["arch"]
+
+                is_os_supported = False
+                is_arch_supported = False
+
+                for supp_plat in self.supported_platforms:
+                    supp_os = supp_plat.get("os", None)
+                    supp_arch = supp_plat.get("arch", None)
+
+                    if supp_os is None or supp_os == os:
+                        is_os_supported = True
+                        if supp_arch is None or supp_arch == arch:
+                            is_arch_supported = True
+
+                if not (is_os_supported and is_arch_supported):
+                    if arch == "x86":
+                        arch = "32-bit"
+                    elif arch == "x86-64":
+                        arch = "64-bit"
+
+                    if os == "osx":
+                        os = "macOS"
+
+                    if not is_os_supported:
+                        arch = ""
+
+                    msg_plat = "{}{}{}".format(arch, " " if arch != "" else "", os)
+
+                    err_msg = "{} is not supported on {}!".format(self.pypi_package, msg_plat)
+
+                    raise OSError(err_msg)
+                raise e
 
     def _add_generated_file(self, fullpath):
         if not isdir(fullpath):


### PR DESCRIPTION
Example config in pyproject.toml:
```toml
[tool.robotpy-build]
base_package = "rev"
unsupported_platforms = [
    { os = "osx" },
    { os = "windows", arch = "x86" }
]
```

Example error messages:
{ os = "osx" }:
    "OSError: robotpy-rev is not supported on macOS!"
{ os = "windows", arch = "x86" }:
    "OSError: robotpy-rev is not supported on 32-bit windows!"
{ arch = "x86" }:
    "OSError: robotpy-rev is not supported on 32-bit versions of Python!"
