### PR TITLE
Add tool to detect supported platforms

### DIFF
--- a/robotpy_build/tool.py
+++ b/robotpy_build/tool.py
@@ -276,6 +276,12 @@ class MavenParser:
         "jetsontx",
     ]
 
+    known_after_archs = [
+        "static",
+        "debug",
+        "staticdebug",
+    ]
+
     @classmethod
     def add_subparser(cls, parent_parser, subparsers):
         parser = subparsers.add_parser(
@@ -350,11 +356,12 @@ class MavenParser:
 
                     for os in self.os_names:
                         for arch in self.known_arch_names:
-                            classifier = os + arch
-                            file_url = f"{dir_url}{art}-{ver}-{classifier}.zip"
+                            for after_arch in self.known_after_archs + [""]:
+                                classifier = os + arch + after_arch
+                                file_url = f"{dir_url}{art}-{ver}-{classifier}.zip"
 
-                            if self.check_url_exists(file_url):
-                                plats[os].add(arch)
+                                if self.check_url_exists(file_url):
+                                    plats[os].add(arch)
 
                     if self.check_url_exists(f"{dir_url}{art}-{ver}-source.zip"):
                         found_source = True
@@ -396,11 +403,11 @@ class MavenParser:
                             idx = m.find(os)
 
                             if idx != -1:
-                                arch = (
-                                    m[idx + len(os) :]
-                                    .replace("static", "")
-                                    .replace("debug", "")
-                                )
+                                arch = m[idx + len(os) :]
+
+                                for after_arch in self.known_after_archs:
+                                    arch = arch.replace(after_arch, "")
+
                                 plats[os].add(arch)
                                 break
 
@@ -440,6 +447,7 @@ def main():
         ImportCreator,
         LibraryRelinker,
         PlatformInfo,
+        MavenParser
     ):
         cls.add_subparser(parent_parser, subparsers).set_defaults(cls=cls)
 

--- a/robotpy_build/tool.py
+++ b/robotpy_build/tool.py
@@ -378,7 +378,9 @@ class MavenParser:
                         if e.code != 404:
                             raise e
                         else:
-                            print("The repo url returned a 404 error. Try using the brute_force flag.")
+                            print(
+                                "The repo url returned a 404 error. Try using the brute_force flag."
+                            )
                             exit()
 
                     found_source = False
@@ -447,7 +449,7 @@ def main():
         ImportCreator,
         LibraryRelinker,
         PlatformInfo,
-        MavenParser
+        MavenParser,
     ):
         cls.add_subparser(parent_parser, subparsers).set_defaults(cls=cls)
 

--- a/robotpy_build/tool.py
+++ b/robotpy_build/tool.py
@@ -11,6 +11,7 @@ from urllib.request import Request, urlopen
 from urllib.error import HTTPError
 from collections import defaultdict
 import toml
+from contextlib import suppress
 
 from .setup import Setup
 from .generator_data import MissingReporter
@@ -288,11 +289,9 @@ class MavenParser:
         return parser
 
     def check_url_exists(self, file_url):
-        try:
+        with suppress(Exception):
             if urlopen(Request(file_url)).code == 200:
                 return True
-        except:
-            pass
         return False
 
     def run(self, args):

--- a/robotpy_build/tool.py
+++ b/robotpy_build/tool.py
@@ -263,20 +263,7 @@ class PlatformInfo:
 
 class MavenParser:
 
-    os_names = ["linux", "windows", "osx"]
-    known_arch_names = [
-        "x86",
-        "x86-64",
-        "aarch64",
-        "arm64",
-        "x64",
-        "athena",
-        "aarch64bionic",
-        "raspbian",
-        "jetsontx",
-    ]
-
-    known_after_archs = [
+    after_archs = [
         "static",
         "debug",
         "staticdebug",
@@ -309,6 +296,12 @@ class MavenParser:
         return False
 
     def run(self, args):
+
+        self.os_names = set()
+        self.arch_names = set()
+        for plat in platforms._platforms.values():
+            self.os_names.add(plat.os)
+            self.arch_names.add(plat.arch)
 
         with open(args.toml_link) as fp:
             config = toml.load(fp)["tool"]["robotpy-build"]
@@ -355,8 +348,8 @@ class MavenParser:
                 if args.brute_force:
 
                     for os in self.os_names:
-                        for arch in self.known_arch_names:
-                            for after_arch in self.known_after_archs + [""]:
+                        for arch in self.arch_names:
+                            for after_arch in self.after_archs + [""]:
                                 classifier = os + arch + after_arch
                                 file_url = f"{dir_url}{art}-{ver}-{classifier}.zip"
 
@@ -407,7 +400,7 @@ class MavenParser:
                             if idx != -1:
                                 arch = m[idx + len(os) :]
 
-                                for after_arch in self.known_after_archs:
+                                for after_arch in self.after_archs:
                                     arch = arch.replace(after_arch, "")
 
                                 plats[os].add(arch)

--- a/robotpy_build/tool.py
+++ b/robotpy_build/tool.py
@@ -6,6 +6,11 @@ from pathlib import PurePosixPath
 import pprint
 import subprocess
 import sys
+import re
+from urllib.request import Request, urlopen
+from urllib.error import HTTPError
+from collections import defaultdict
+import toml
 
 from .setup import Setup
 from .generator_data import MissingReporter
@@ -254,6 +259,171 @@ class PlatformInfo:
 
         print("override keys:")
         pprint.pprint(platforms.get_platform_override_keys(p))
+
+
+class MavenParser:
+
+    os_names = ["linux", "windows", "osx"]
+    known_arch_names = [
+        "x86",
+        "x86-64",
+        "aarch64",
+        "arm64",
+        "x64",
+        "athena",
+        "aarch64bionic",
+        "raspbian",
+        "jetsontx",
+    ]
+
+    @classmethod
+    def add_subparser(cls, parent_parser, subparsers):
+        parser = subparsers.add_parser(
+            "parse-maven",
+            help="Find supported platforms from a pyproject.toml",
+            parents=[parent_parser],
+        )
+        parser.add_argument(
+            "toml_link", help="Ex: pyproject.toml",
+        )
+        parser.add_argument(
+            "-b",
+            "--brute_force",
+            action="store_true",
+            help="Try known os and arch combinations instead of parsing html (needed for rev)",
+        )
+        return parser
+
+    def check_url_exists(self, file_url):
+        try:
+            if urlopen(Request(file_url)).code == 200:
+                return True
+        except:
+            pass
+        return False
+
+    def run(self, args):
+
+        with open(args.toml_link) as fp:
+            config = toml.load(fp)["tool"]["robotpy-build"]
+
+            wrappers = {}
+            if "wrappers" in config:
+                wrappers = {
+                    k: v
+                    for (k, v) in config["wrappers"].items()
+                    if "maven_lib_download" in v
+                }
+
+            static_libs = {}
+            if "static_libs" in config:
+                static_libs = {
+                    k: v
+                    for (k, v) in config["static_libs"].items()
+                    if "maven_lib_download" in v
+                }
+
+            if wrappers == {} and static_libs == {}:
+                print("No maven_lib_downloads in pyproject.toml")
+                exit()
+
+            for w_name, wrapper in {**wrappers, **static_libs}.items():
+
+                if "maven_lib_download" not in wrapper:
+                    continue
+
+                mvl = wrapper["maven_lib_download"]
+
+                repo_url = mvl["repo_url"]
+                grp = mvl["group_id"].replace(".", "/")
+                art = mvl["artifact_id"]
+                ver = mvl["version"]
+
+                dir_url = f"{repo_url}/{grp}/{art}/{ver}/"
+
+                plats = defaultdict(set)
+
+                found_source = False
+                source_name = None
+
+                if args.brute_force:
+
+                    for os in self.os_names:
+                        for arch in self.known_arch_names:
+                            classifier = os + arch
+                            file_url = f"{dir_url}{art}-{ver}-{classifier}.zip"
+
+                            if self.check_url_exists(file_url):
+                                plats[os].add(arch)
+
+                    if self.check_url_exists(f"{dir_url}{art}-{ver}-source.zip"):
+                        found_source = True
+                        source_name = "source"
+
+                    if self.check_url_exists(f"{dir_url}{art}-{ver}-sources.zip"):
+                        found_source = True
+                        source_name = "sources"
+
+                else:
+                    try:
+                        html = str(urlopen(Request(dir_url)).read())
+                    except HTTPError as e:
+                        if e.code != 404:
+                            raise e
+                        else:
+                            print("The repo url returned a 404 error. Try using the brute_force flag.")
+                            exit()
+
+                    found_source = False
+                    source_name = None
+
+                    if "source.zip" in html:
+                        found_source = True
+                        source_name = "source"
+
+                    if "sources.zip" in html:
+                        found_source = True
+                        source_name = "sources"
+
+                    # matches = re.findall('\.zip">(.*?)\.zip</a>', html, re.I) # match on text
+                    matches = re.findall('href="(.*?)">', html, re.I)  # match on links
+                    matches = [
+                        m[:-4] for m in matches if m[-4:] == ".zip"
+                    ]  # match on zip files and remove extension
+
+                    for m in matches:
+                        for os in self.os_names:
+                            idx = m.find(os)
+
+                            if idx != -1:
+                                arch = (
+                                    m[idx + len(os) :]
+                                    .replace("static", "")
+                                    .replace("debug", "")
+                                )
+                                plats[os].add(arch)
+                                break
+
+                # Formatting
+                print()
+                print(f"Wrapper / static_lib :: {w_name}")
+                print(f"Artifact ID :: {art}")
+                print()
+
+                if found_source:
+                    print("This repo appears to provide sources.")
+                    print("The name of the source file is:", source_name)
+                    print()
+
+                plat_str = "supported_platforms = [\n"
+                for os in plats:
+                    for arch in plats[os]:
+                        plat_str += '    {{ os = "{}", arch = "{}" }},\n'.format(
+                            os, arch
+                        )
+                plat_str += "]"
+
+                print(plat_str)
 
 
 def main():


### PR DESCRIPTION
The tool finds `maven_lib_downloads` in a given pyproject.toml and finds supported platforms by scraping html. A brute force option is given when html is not available (rev).

Ex. 
```bash
robotpy-build parse-maven pyproject.toml
```
Output:
```bash
Wrapper / static_lib :: hal
Artifact ID :: hal-cpp

This repo appears to provide sources.
The name of the source file is: sources

supported_platforms = [
    { os = "linux", arch = "raspbian" },
    { os = "linux", arch = "aarch64bionic" },
    { os = "linux", arch = "x86-64" },
    { os = "linux", arch = "athena" },
    { os = "osx", arch = "x86-64" },
    { os = "windows", arch = "x86" },
    { os = "windows", arch = "x86-64" },
]
```
