### PR TITLE
Fix circular dependencies in object registration

### DIFF
--- a/robotpy_build/templates/cls.cpp.j2
+++ b/robotpy_build/templates/cls.cpp.j2
@@ -45,40 +45,87 @@ using {{ using.raw_type }};
   - class enums
   - class methods
   - global methods
+
+  Additionally, we use two-part initialization to ensure that documentation
+  strings are generated properly. First part is to register the class with
+  pybind11, second part is to generate all the methods/etc for it.
+
 #}
 
-void init_{{ mod_fn }}(py::module &m) {
+{% for cls in header.classes
+   if cls.namespace and not cls.parent and not cls.data.ignore and cls.template is not defined %}
+  using namespace {{ cls.namespace }};
+{% endfor %}
+
+
+struct rpybuild_{{ mod_fn }}_initializer {
 
 {# namespaces/typealiases #}
 {% for cls in header.classes if not cls.data.ignore and cls.template is not defined %}
   {{ pybind11.cls_using(cls) }}
 {% endfor %}
 
-{# subpackages #}
 {% for pkg, vname in subpackages.items() %}
-  auto {{ vname }} = m.def_submodule("{{ pkg }}");
+  py::module {{ vname }};
 {% endfor %}
 
-{# define global enums in case they are used as default args #}  
-{% for enum in header.enums if not enum.data.ignore %}
-  {{ pybind11.genenum(enum.x_module_var, enum) }}
+{# enums #}
+{% for enum in header.enums if "name" in enum and not enum.data.ignore %}
+  {{ pybind11.enum_decl(enum.x_module_var, enum) }} enum{{ loop.index }};
+{% endfor %}
+
+{# template decls #}
+{% for name, tmpl_data in templates.items() %}
+  rpygen::bind_{{ tmpl_data.x_qualname_ }}<{{ tmpl_data.params | join(', ') }}> tmplCls{{ loop.index }};
+{% endfor %}
+
+{# class decls #}
+{%- for cls in header.classes
+     if not cls.parent and not cls.data.ignore and cls.template is not defined %}
+  {{ pybind11.cls_decl(cls) }}
+{% endfor %}
+
+  py::module &m;
+
+  {# register classes with pybind11 #}
+  rpybuild_{{ mod_fn }}_initializer(py::module &m) :
+
+  {% for pkg, vname in subpackages.items() %}
+    {{ vname }}(m.def_submodule("{{ pkg }}")),
+  {% endfor %}
+
+  {% for enum in header.enums if "name" in enum and not enum.data.ignore %}
+    enum{{ loop.index }}{{ pybind11.enum_init(enum.x_module_var, enum) }},
+  {% endfor %}
+
+  {% for name, tmpl_data in templates.items() %}
+    tmplCls{{ loop.index }}({{ tmpl_data.x_module_var }}, "{{ name }}"),
+  {% endfor %}
+
+  {% for cls in header.classes
+     if not cls.parent and not cls.data.ignore and cls.template is not defined %}
+    {{ pybind11.cls_init(cls, '"' + cls.x_name + '"') }}
+  {% endfor %}
+
+    m(m)
+  {}
+
+void finish() {
+
+{# enums #}
+{% for enum in header.enums if "name" in enum and not enum.data.ignore %}
+  enum{{ loop.index }}{{ pybind11.enum_def(enum.x_module_var, enum) }}
 {% endfor %}
 
 {# templates #}
-{% for name, tmpl_data in templates.items() %}
-  rpygen::bind_{{ tmpl_data.x_qualname_ }}<{{ tmpl_data.params | join(', ') }}>({{ tmpl_data.x_module_var }}, "{{ name }}");
-{% endfor %}
-
-{# class declarations #}
-{%- for cls in header.classes
-   if not cls.parent and not cls.data.ignore and cls.template is not defined %}
-  {{ pybind11.cls_decl(cls, cls.x_varname, '"' + cls.x_name + '"') }}
+{% for _ in templates.items() %}
+  tmplCls{{ loop.index }}.finish();
 {% endfor %}
 
 {# class methods #}
 {%- for cls in header.classes
    if not cls.parent and not cls.data.ignore and cls.template is not defined %}
-  {{ pybind11.cls_methods(cls, cls.x_varname) }}
+  {{ pybind11.cls_def(cls, cls.x_varname) }}
 {% endfor %}
 
 {# global methods #}
@@ -92,4 +139,17 @@ void init_{{ mod_fn }}(py::module &m) {
 
   {{ data.inline_code }}
 {% endif %}
+}
+
+}; // struct rpybuild_{{ mod_fn }}_initializer
+
+static std::unique_ptr<rpybuild_{{ mod_fn }}_initializer> cls;
+
+void begin_init_{{ mod_fn }}(py::module &m) {
+  cls = std::make_unique<rpybuild_{{ mod_fn }}_initializer>(m);
+}
+
+void finish_init_{{ mod_fn }}() {
+  cls->finish();
+  cls.reset();
 }

--- a/robotpy_build/templates/cls_tmpl_impl.hpp.j2
+++ b/robotpy_build/templates/cls_tmpl_impl.hpp.j2
@@ -15,16 +15,29 @@ using {{ using.raw_type }};
 {% endfor %}
 
 template <{{ cls.x_template_parameter_list }}>
-inline void bind_{{ cls.x_qualname_ }}(py::module &m, const char * clsName) {
+struct bind_{{ cls.x_qualname_ }} {
 
     {{ pybind11.cls_using(cls) }}
 
-    {# TODO: embedded structs will fail here #}
-    {{ pybind11.cls_decl(cls, cls.x_varname, "clsName") }}
+    {{ pybind11.cls_decl(cls) }}
 
-    {{ pybind11.cls_methods(cls, cls.x_varname) }}
+    py::module &m;
+    std::string clsName;
+
+bind_{{ cls.x_qualname_ }}(py::module &m, const char * clsName) :
+    {# TODO: embedded structs will fail here #}
+    {{ pybind11.cls_init(cls, "clsName") }}
+    m(m),
+    clsName(clsName)
+{}
+
+void finish() {
+
+    {{ pybind11.cls_def(cls, cls.x_varname) }}
 
     {{ cls.data.template_inline_code }}
 }
+
+}; // struct bind_{{ cls.x_qualname_ }}
 
 }; // namespace rpygen

--- a/robotpy_build/templates/pybind11.cpp.j2
+++ b/robotpy_build/templates/pybind11.cpp.j2
@@ -198,10 +198,16 @@
   {%- endif -%}
 {%- endmacro -%}
 
-{%- macro genenum(scope, enum) %}
-{%- if 'name' in enum -%}
-py::enum_<{{ enum.x_namespace }}{{ enum.name }}>({{ scope }}, "{{ enum.x_name }}"
+{%- macro enum_decl(scope, enum) %}
+  py::enum_<{{ enum.x_namespace }}{{ enum.name }}>
+{%- endmacro -%}
+
+{%- macro enum_init(scope, enum) %}
+  ({{ scope }}, "{{ enum.x_name }}"
   {{ doc(enum, ',', '') }})
+{%- endmacro -%}
+
+{%- macro enum_def(scope, enum) %}
   {% for val in enum['values'] if not val.data.ignore %}
     .value("{{ val.x_name }}", {{ enum.x_namespace }}{{ enum.name }}::{{ val.name }}
     {%- if val.x_doc_quoted %},
@@ -211,7 +217,6 @@ py::enum_<{{ enum.x_namespace }}{{ enum.name }}>({{ scope }}, "{{ enum.x_name }}
     {%- endif -%})
   {% endfor -%}
   ;
-{%- endif -%}
 {% endmacro -%}
 
 {%- macro unnamed_enum(x, enums) %}
@@ -223,9 +228,6 @@ py::enum_<{{ enum.x_namespace }}{{ enum.name }}>({{ scope }}, "{{ enum.x_name }}
 {% endmacro -%}
 
 {%- macro cls_using(cls) -%}
-  {% if cls.namespace and not cls.parent %}
-    using namespace {{ cls.namespace }};
-  {% endif %}
   {% if cls.parent and '<' not in cls.x_qualname %}
   using {{ cls.name }} = {{ cls.x_qualname }};
   {% endif %}
@@ -237,7 +239,7 @@ py::enum_<{{ enum.x_namespace }}{{ enum.name }}>({{ scope }}, "{{ enum.x_name }}
   {% endfor %}
 {% endmacro -%}
 
-{%- macro cls_decl(cls, varname, name) -%}
+{%- macro cls_decl(cls) -%}
   py::class_<typename {{ cls.x_qualname }}
     {%- if cls.data.nodelete -%}
       , std::unique_ptr<typename {{ cls.x_qualname }}, py::nodelete>
@@ -251,9 +253,22 @@ py::enum_<{{ enum.x_namespace }}{{ enum.name }}>({{ scope }}, "{{ enum.x_name }}
     {%- if cls.x_inherits -%}
       , {{ cls.x_inherits | join(', ', attribute='class') }}
     {%- endif -%}
+    > {{ cls.x_varname }};
 
-    >
-      {{ varname }}(
+    {% for enum in cls.enums.public if "name" in enum and not enum.data.ignore %}
+    {{ enum_decl(cls.x_varname, enum) }} {{ cls.x_varname }}_enum{{ loop.index }};
+    {% endfor %}
+
+    {# recurse #}
+    {% for ncls in cls.nested_classes
+      if not ncls.data.ignore and ncls.template is not defined %}
+      {{ cls_decl(ncls) }}
+    {% endfor -%}
+
+{%- endmacro -%}
+
+{%- macro cls_init(cls, name) -%}
+    {{ cls.x_varname }}(
 
     {%- if cls.parent -%}
       {{ cls.parent.x_varname }}
@@ -268,23 +283,28 @@ py::enum_<{{ enum.x_namespace }}{{ enum.name }}>({{ scope }}, "{{ enum.x_name }}
       , py::is_final()
     {%- endif -%}
 
-    );
-  
-  {{ doc(cls, varname + '.doc() =', ';') }}
-  
-  {# define class enums in case they are used as default args #}
-  {% for enum in cls.enums.public if not enum.data.ignore %}
-    {{ genenum(cls.x_varname, enum) }}
+    ),
+
+  {% for enum in cls.enums.public if "name" in enum and not enum.data.ignore %}
+    {{ cls.x_varname }}_enum{{ loop.index }}{{ enum_init(cls.x_varname, enum) }},
   {% endfor %}
 
   {# recurse #}
   {% for ncls in cls.nested_classes
      if not ncls.data.ignore and ncls.template is not defined %}
-    {{ cls_decl(ncls, ncls.x_varname, '"' + ncls.x_name + '"') }}
+    {{ cls_init(ncls, '"' + ncls.x_name + '"') }}
   {% endfor -%}
+
 {%- endmacro -%}
 
-{%- macro cls_methods(cls, varname) -%}
+{%- macro cls_def(cls, varname) -%}
+
+  {% for enum in cls.enums.public if "name" in enum and not enum.data.ignore %}
+    {{ cls.x_varname }}_enum{{ loop.index }}{{ enum_def(cls.x_varname, enum) }}
+  {% endfor %}
+
+  {{ doc(cls, varname + '.doc() =', ';') }}
+
   {{ varname }}
   {# default constructor if not defined #}
   {% if not cls.x_has_constructor and not cls.data.nodelete and not cls.data.force_no_default_constructor %}
@@ -312,7 +332,7 @@ py::enum_<{{ enum.x_namespace }}{{ enum.name }}>({{ scope }}, "{{ enum.x_name }}
   {#- recurse -#}
   {%- for ncls in cls.nested_classes 
       if not ncls.data.ignore and ncls.template is not defined %}
-  {{ cls_methods(ncls, ncls.x_varname) }}
+  {{ cls_def(ncls, ncls.x_varname) }}
   {% endfor -%}
 
 {%- endmacro -%}

--- a/robotpy_build/wrapper.py
+++ b/robotpy_build/wrapper.py
@@ -705,7 +705,8 @@ class Wrapper:
     def _write_wrapper_hpp(self, outdir, classdeps):
 
         decls = []
-        calls = []
+        begin_calls = []
+        finish_calls = []
 
         def _clean(n):
             tmpl_idx = n.find("<")
@@ -747,8 +748,10 @@ class Wrapper:
         ordering.extend(toposort.toposort_flatten(to_sort, sort=True))
 
         for name in ordering:
-            decls.append(f"void init_{name}(py::module &m);")
-            calls.append(f"    init_{name}(m);")
+            decls.append(f"void begin_init_{name}(py::module &m);")
+            decls.append(f"void finish_init_{name}();")
+            begin_calls.append(f"    begin_init_{name}(m);")
+            finish_calls.append(f"    finish_init_{name}();")
 
         content = (
             inspect.cleandoc(
@@ -762,13 +765,16 @@ class Wrapper:
         ##DECLS##
 
         static void initWrapper(py::module &m) {
-        ##CALLS##
+        ##BEGIN_CALLS##
+
+        ##FINISH_CALLS##
         }
         
         """
             )
             .replace("##DECLS##", "\n".join(decls))
-            .replace("##CALLS##", "\n".join(calls))
+            .replace("##BEGIN_CALLS##", "\n".join(begin_calls))
+            .replace("##FINISH_CALLS##", "\n".join(finish_calls))
         )
 
         with open(join(outdir, "rpygen_wrapper.hpp"), "w") as fp:

--- a/tests/cpp/gen/ft/tbasic.yml
+++ b/tests/cpp/gen/ft/tbasic.yml
@@ -6,6 +6,12 @@ classes:
     - T
     attributes:
       t:
+    template_inline_code: |
+      cls_TBasic
+        .def("__repr__", [=](const TBasic<T> &self){
+          // checking to see if clsName is available
+          return "<" + clsName + ">";
+        });
   
 templates:
   TBasicString:

--- a/tests/cpp/gen/ft/tdependent_using.yml
+++ b/tests/cpp/gen/ft/tdependent_using.yml
@@ -1,0 +1,14 @@
+---
+classes:
+  TDependentUsing:
+    shared_ptr: true
+    template_params:
+    - T
+    typealias:
+    - VectorType = std::vector<T>
+  
+templates:
+  TDependentUsingInt:
+    qualname: whatever::TDependentUsing
+    params:
+    - int

--- a/tests/cpp/pyproject.toml.tmpl
+++ b/tests/cpp/pyproject.toml.tmpl
@@ -64,6 +64,7 @@ generate = [
     {tconcrete = "templates/tconcrete.h"},
 
     {tbasic = "templates/basic.h"},
+    {tdependent_using = "templates/dependent_using.h"},
     {tfn = "templates/fn.h" },
     {tnumeric = "templates/numeric.h"},
     {tnested = "templates/nested.h"},

--- a/tests/cpp/rpytest/ft/__init__.py
+++ b/tests/cpp/rpytest/ft/__init__.py
@@ -29,6 +29,7 @@ from ._rpytest_ft import (
     TChildGetN6,
     TClassWithFn,
     TConcrete,
+    TDependentUsingInt,
     TOuter,
     TcrtpConcrete,
     TcrtpFwdConcrete,

--- a/tests/cpp/rpytest/ft/include/templates/dependent_using.h
+++ b/tests/cpp/rpytest/ft/include/templates/dependent_using.h
@@ -1,0 +1,22 @@
+
+#pragma once
+
+#include <vector>
+
+// Testcase: using directive that depends on the template parameter
+
+namespace whatever
+{
+
+    template <typename T>
+    struct TDependentUsing
+    {
+        using VectorType = std::vector<T>;
+
+        T getThird(VectorType t)
+        {
+            return t.at(2);
+        }
+    };
+
+}; // namespace whatever

--- a/tests/test_ft_templates.py
+++ b/tests/test_ft_templates.py
@@ -10,6 +10,11 @@ def test_basic_template():
     assert s.getT() == "string"
 
 
+def test_dependent_using():
+    du = ft.TDependentUsingInt()
+    assert du.getThird([1, 2, 3]) == 3
+
+
 def test_classwithfn():
     assert ft.TClassWithFn.getT(1) == 1
     assert ft.TClassWithFn.getT(False) is False


### PR DESCRIPTION
- Use a two-phase registration so that all objects are registered before trying to use them
- Fixes #43