### PR TITLE
Add Python 3.10 to CI

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -38,7 +38,12 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-18.04]
-        python_version: [3.6, 3.7, 3.8, 3.9]
+        python_version:
+        - 3.6
+        - 3.7
+        - 3.8
+        - 3.9
+        - 3.10-dev
         architecture: [x86, x64]
         exclude:
         - os: macos-latest

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -43,7 +43,7 @@ jobs:
         - 3.7
         - 3.8
         - 3.9
-        - 3.10-dev
+        - 3.10
         architecture: [x86, x64]
         exclude:
         - os: macos-latest

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -39,11 +39,11 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, ubuntu-18.04]
         python_version:
-        - 3.6
-        - 3.7
-        - 3.8
-        - 3.9
-        - 3.10
+        - '3.6'
+        - '3.7'
+        - '3.8'
+        - '3.9'
+        - '3.10'
         architecture: [x86, x64]
         exclude:
         - os: macos-latest


### PR DESCRIPTION
Python 3.10.0rc1 is now available. We should run our tests early to see if we can catch any bugs before the final release.