### PR TITLE
Use the pybind11 smart_holder branch

### DIFF
--- a/robotpy_build/command/build_ext.py
+++ b/robotpy_build/command/build_ext.py
@@ -76,6 +76,7 @@ class BuildExt(build_ext):
         elif ct == "msvc":
             opts.append(cpp_flag(self.compiler, "/", ":"))
         for ext in self.extensions:
+            ext.define_macros.append(("PYBIND11_USE_SMART_HOLDER_AS_DEFAULT", "1"))
             ext.extra_compile_args = opts
             ext.extra_link_args = link_opts
 

--- a/robotpy_build/generator_data.py
+++ b/robotpy_build/generator_data.py
@@ -144,10 +144,7 @@ class GeneratorData:
                 "methods",
             )
             if result or cls_data["missing"]:
-                # show this first
-                r = {"shared_ptr": True}
-                r.update(result)
-                all_cls_data[str(cls_key)] = r
+                all_cls_data[str(cls_key)] = result
         if all_cls_data:
             data["classes"] = all_cls_data
 

--- a/robotpy_build/hooks_datacfg.py
+++ b/robotpy_build/hooks_datacfg.py
@@ -302,13 +302,7 @@ class ClassData(Model):
     #: Set the python name of the class to this
     rename: Optional[str] = None
 
-    #: If the type was created as a shared_ptr (such as via std::make_shared)
-    #: then pybind11 needs to be informed of this.
-    #:
-    #: https://github.com/pybind/pybind11/issues/1215
-    #:
-    #: One way you can tell we messed this up is if there's a double-free
-    #: error and the stack trace involves a unique_ptr destructor
+    #: This is deprecated and has no effect
     shared_ptr: bool = True
 
     #: If specified, put the class in a sub.pack.age. Ignored

--- a/robotpy_build/templates/cls.cpp.j2
+++ b/robotpy_build/templates/cls.cpp.j2
@@ -57,6 +57,10 @@ using {{ using.raw_type }};
   using namespace {{ cls.namespace }};
 {% endfor %}
 
+{% for cls in header.classes if cls.data.nodelete %}
+PYBIND11_TYPE_CASTER_BASE_HOLDER(typename {{ cls.x_qualname }}, std::unique_ptr<typename {{ cls.x_qualname }}, py::nodelete>);
+{% endfor %}
+
 
 struct rpybuild_{{ mod_fn }}_initializer {
 

--- a/robotpy_build/templates/cls_trampoline.hpp.j2
+++ b/robotpy_build/templates/cls_trampoline.hpp.j2
@@ -80,7 +80,7 @@ template <typename PyTrampolineBase
     , {{ cls.x_template_parameter_list }}
 {%- endif -%}
     , typename CxxBase = PyTrampolineBase>
-struct Py{{ cls.x_qualname_ }} : PyTrampolineBase {
+struct Py{{ cls.x_qualname_ }} : PyTrampolineBase, virtual py::trampoline_self_life_support {
     using PyTrampolineBase::PyTrampolineBase;
 {% endif %}
 

--- a/robotpy_build/templates/pybind11.cpp.j2
+++ b/robotpy_build/templates/pybind11.cpp.j2
@@ -248,8 +248,6 @@
   py::class_<typename {{ cls.x_qualname }}
     {%- if cls.data.nodelete -%}
       , std::unique_ptr<typename {{ cls.x_qualname }}, py::nodelete>
-    {%- elif cls.data.shared_ptr -%}
-      , std::shared_ptr<typename {{ cls.x_qualname }}>
     {%- endif -%}
     {%- if cls.x_has_trampoline -%}
       , {{ cls.x_trampoline_var }}

--- a/tests/cpp/gen/ft/docstrings_append.yml
+++ b/tests/cpp/gen/ft/docstrings_append.yml
@@ -9,7 +9,6 @@ enums:
           Useful extra information about this value
 classes:
   DocAppendClass:
-    shared_ptr: true
     doc_append: |
       Useful extra information about this sweet class
     attributes:
@@ -22,7 +21,6 @@ classes:
           Useful extra information about this fn
   
   DocWithTemplate:
-    shared_ptr: true
     template_params:
     - T
 

--- a/tests/cpp/gen/ft/ignore.yml
+++ b/tests/cpp/gen/ft/ignore.yml
@@ -23,7 +23,6 @@ classes:
   IgnoredClass:
     ignore: true
   ClassWithIgnored:
-    shared_ptr: true
     attributes:
       ignoredProp:
         ignore: true

--- a/tests/cpp/gen/ft/rename.yml
+++ b/tests/cpp/gen/ft/rename.yml
@@ -15,7 +15,6 @@ functions:
         name: y
 classes:
   OriginalClass:
-    shared_ptr: true
     rename: RenamedClass
     attributes:
       originalProp:

--- a/tests/cpp/gen/ft/subpkg.yml
+++ b/tests/cpp/gen/ft/subpkg.yml
@@ -4,11 +4,9 @@ functions:
     subpackage: subpkg
 classes:
   SPClass:
-    shared_ptr: true
     subpackage: subpkg
   
   SPTemplate:
-    shared_ptr: true
     template_params:
     - T
 

--- a/tests/cpp/gen/ft/tbase.yml
+++ b/tests/cpp/gen/ft/tbase.yml
@@ -1,7 +1,6 @@
 ---
 classes:
   TBase:
-    shared_ptr: true
     methods:
       get:
       baseFn:

--- a/tests/cpp/gen/ft/tbasic.yml
+++ b/tests/cpp/gen/ft/tbasic.yml
@@ -1,7 +1,6 @@
 ---
 classes:
   TBasic:
-    shared_ptr: true
     template_params:
     - T
     attributes:

--- a/tests/cpp/gen/ft/tconcrete.yml
+++ b/tests/cpp/gen/ft/tconcrete.yml
@@ -1,6 +1,5 @@
 classes:
   TConcrete:
-    shared_ptr: true
     methods:
       concrete:
 

--- a/tests/cpp/gen/ft/tcrtp.yml
+++ b/tests/cpp/gen/ft/tcrtp.yml
@@ -1,6 +1,5 @@
 classes:
   TCrtp:
-    shared_ptr: true
     force_no_default_constructor: true
     template_params:
     - T

--- a/tests/cpp/gen/ft/tcrtpfwd.yml
+++ b/tests/cpp/gen/ft/tcrtpfwd.yml
@@ -1,6 +1,5 @@
 classes:
   TCrtpFwd:
-    shared_ptr: true
     force_no_default_constructor: true
     template_params:
     - T

--- a/tests/cpp/gen/ft/tdependent_param.yml
+++ b/tests/cpp/gen/ft/tdependent_param.yml
@@ -1,7 +1,6 @@
 ---
 classes:
   TDependentParam:
-    shared_ptr: true
     template_params:
     - T
     typealias:

--- a/tests/cpp/gen/ft/tdependent_using.yml
+++ b/tests/cpp/gen/ft/tdependent_using.yml
@@ -1,7 +1,6 @@
 ---
 classes:
   TDependentUsing:
-    shared_ptr: true
     template_params:
     - T
     typealias:

--- a/tests/cpp/gen/ft/tfn.yml
+++ b/tests/cpp/gen/ft/tfn.yml
@@ -2,7 +2,6 @@
 
 classes:
   TClassWithFn:
-    shared_ptr: true
     methods:
       getT:
         template_impls:

--- a/tests/cpp/gen/ft/tnested.yml
+++ b/tests/cpp/gen/ft/tnested.yml
@@ -2,12 +2,10 @@
 
 classes:
   Outer:
-    shared_ptr: true
     template_params:
     - T
   
   Outer::Inner:
-    shared_ptr: true
     attributes:
       t:
 

--- a/tests/cpp/gen/ft/tnumeric.yml
+++ b/tests/cpp/gen/ft/tnumeric.yml
@@ -1,17 +1,14 @@
 ---
 classes:
   TBaseGetN:
-    shared_ptr: true
     template_params:
     - int N
     methods:
       getIt:
   
   TChildGetN4:
-    shared_ptr: true
   
   TChildGetN:
-    shared_ptr: true
     template_params:
     - int N
     

--- a/tests/cpp/gen/ft/virtual_xform.yml
+++ b/tests/cpp/gen/ft/virtual_xform.yml
@@ -4,7 +4,6 @@ functions:
   check_impure_io:
 classes:
   VBase:
-    shared_ptr: true
     methods:
       pure_io:
         param_override:
@@ -41,7 +40,6 @@ classes:
           }
 
   VChild:
-    shared_ptr: true
     methods:
       pure_io:
         param_override:


### PR DESCRIPTION
- No longer need to include 'shared_ptr: true', as this is automatic now

I think this won't work for something that is templated and marked as nodelete. Need to add a test to check.