### PR TITLE
Set enum values in the initialization stage since they can't have dependencies

### DIFF
--- a/robotpy_build/templates/cls.cpp.j2
+++ b/robotpy_build/templates/cls.cpp.j2
@@ -112,14 +112,21 @@ struct rpybuild_{{ mod_fn }}_initializer {
   {% endfor %}
 
     m(m)
-  {}
+  {
+    {#
+      enums can go in the initializer because they cant have dependencies,
+      and then we dont need to figure out class dependencies for enum arguments
+    #}
+    {% for enum in header.enums if "name" in enum and not enum.data.ignore %}
+      enum{{ loop.index }}{{ pybind11.enum_def(enum.x_module_var, enum) }}
+    {% endfor %}
+
+    {% for cls in header.classes %}
+    {{ pybind11.cls_def_enum(cls, cls.x_varname) }}
+    {% endfor %}
+  }
 
 void finish() {
-
-{# enums #}
-{% for enum in header.enums if "name" in enum and not enum.data.ignore %}
-  enum{{ loop.index }}{{ pybind11.enum_def(enum.x_module_var, enum) }}
-{% endfor %}
 
 {# templates #}
 {% for tdata in templates.values() %}

--- a/robotpy_build/templates/cls_tmpl_impl.hpp.j2
+++ b/robotpy_build/templates/cls_tmpl_impl.hpp.j2
@@ -29,7 +29,9 @@ bind_{{ cls.x_qualname_ }}(py::module &m, const char * clsName) :
     {{ pybind11.cls_init(cls, "clsName") }}
     m(m),
     clsName(clsName)
-{}
+{
+    {{ pybind11.cls_def_enum(cls, cls.x_varname) }}
+}
 
 void finish(const char * set_doc = NULL, const char * add_doc = NULL) {
 

--- a/robotpy_build/templates/pybind11.cpp.j2
+++ b/robotpy_build/templates/pybind11.cpp.j2
@@ -300,11 +300,13 @@
 
 {%- endmacro -%}
 
-{%- macro cls_def(cls, varname) -%}
-
+{%- macro cls_def_enum(cls, varname) %}
   {% for enum in cls.enums.public if "name" in enum and not enum.data.ignore %}
     {{ cls.x_varname }}_enum{{ loop.index }}{{ enum_def(cls.x_varname, enum) }}
   {% endfor %}
+{% endmacro -%}
+
+{%- macro cls_def(cls, varname) -%}
 
   {{ doc(cls, varname + '.doc() =', ';') }}
 


### PR DESCRIPTION
- Fixes issue with a method that had another class' enum value as a default argument
- Not going to write a test for this since it seems a bit random