### PR TITLE
Add features to properly support methods with ref-qualifiers

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -13,18 +13,18 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: psf/black@stable
   
   check-doc:
     runs-on: ubuntu-18.04
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
       with:
         python-version: 3.8
     - name: Sphinx
@@ -53,7 +53,7 @@ jobs:
           architecture: x86
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -99,7 +99,7 @@ jobs:
       image: "${{ matrix.container }}"
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
@@ -129,11 +129,11 @@ jobs:
     if: github.event_name == 'push' && startsWith(github.event.ref, 'refs/tags')
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
 
-    - uses: actions/setup-python@v2
+    - uses: actions/setup-python@v4
 
     - run: pip --disable-pip-version-check install build
 

--- a/robotpy_build/hooks.py
+++ b/robotpy_build/hooks.py
@@ -567,6 +567,23 @@ class Hooks:
                     f"{fn['name']}: cannot specify ignore_pure for function that isn't pure"
                 )
 
+            if data.trampoline_cpp_code and (not fn["override"] and not fn["virtual"]):
+                raise ValueError(
+                    f"{fn['name']}: cannot specify trampoline_cpp_code for a non-virtual method"
+                )
+
+            if data.virtual_xform and (not fn["override"] and not fn["virtual"]):
+                raise ValueError(
+                    f"{fn['name']}: cannot specify virtual_xform for a non-virtual method"
+                )
+
+            if fn.get("ref_qualifiers", "") == "&&":
+                # pybind11 doesn't support this, user must fix it
+                if not data.ignore_py and not data.cpp_code:
+                    raise ValueError(
+                        f"{fn['name']}: has && ref-qualifier which cannot be directly bound by pybind11, must specify cpp_code or ignore_py"
+                    )
+
         # if "hook" in data:
         #     eval(data["hook"])(fn, data)
 
@@ -829,6 +846,7 @@ class Hooks:
                         (fn["override"] or fn["virtual"])
                         and method_data.cpp_code
                         and not method_data.virtual_xform
+                        and not method_data.trampoline_cpp_code
                         and not cls["final"]
                         and not class_data.force_no_trampoline
                     )

--- a/robotpy_build/hooks_datacfg.py
+++ b/robotpy_build/hooks_datacfg.py
@@ -109,6 +109,13 @@ class FunctionData(Model):
     #: If True, don't wrap this, but provide a pure virtual implementation
     ignore_pure: bool = False
 
+    #: Most of the time, you will want to specify ``ignore`` instead.
+    #:
+    #: If True, don't expose this function to python. If a trampoline is supposed
+    #: to be generated, it will still be generated. You will likely want to use
+    #: ``trampoline_cpp_code`` if you specify this.
+    ignore_py: bool = False
+
     #: Generate this in an `#ifdef`
     ifdef: Optional[str] = None
     #: Generate this in an `#ifndef`
@@ -156,6 +163,9 @@ class FunctionData(Model):
     #: list is the template parameters for that function
     template_impls: Optional[List[List[str]]] = None
 
+    #: Specify custom C++ code for the virtual function trampoline
+    trampoline_cpp_code: Optional[str] = None
+
     #: Specify a transformation lambda to be used when this virtual function
     #: is called from C++. This inline code should be a lambda that has the same
     #: arguments as the original C++ virtual function, except the first argument
@@ -186,6 +196,14 @@ class FunctionData(Model):
             if v is None:
                 value[k] = FunctionData()
         return value
+
+    @validator("virtual_xform")
+    def validate_virtual_xform(cls, v, values):
+        if v and values.get("trampoline_cpp_code"):
+            raise ValueError(
+                f"cannot specify trampoline_cpp_code and virtual_xform for the same method"
+            )
+        return v
 
 
 if not _generating_documentation:

--- a/robotpy_build/mangle.py
+++ b/robotpy_build/mangle.py
@@ -97,6 +97,12 @@ def trampoline_signature(fn):
 
     if fn["const"]:
         names.append("K")
+    refqual = fn["ref_qualifiers"]
+    if refqual:
+        if refqual == "&":
+            names.append("R")
+        if refqual == "&&":
+            names.append("O")
 
     names.append(fn["name"])
 

--- a/robotpy_build/templates/cls.cpp.j2
+++ b/robotpy_build/templates/cls.cpp.j2
@@ -151,7 +151,7 @@ void finish() {
 
 {# global methods #}
 {%- if header.functions %}
-  {% for fn in header.functions if not fn.data.ignore -%}
+  {% for fn in header.functions if not fn.data.ignore and not fn.data.ignore_py -%}
     {{ fn.x_module_var }}{{ pybind11.genmethod(None, fn, None) }};
   {% endfor %};
 {% endif %}

--- a/robotpy_build/templates/cls_trampoline.hpp.j2
+++ b/robotpy_build/templates/cls_trampoline.hpp.j2
@@ -148,7 +148,10 @@ struct PyTrampoline_{{ cls.x_qualname_ }} : PyTrampolineBase, virtual py::trampo
 #ifndef RPYGEN_DISABLE_{{ trampoline_signature(fn) }}
     {{ fn.rtnType }} {{ fn.name }}({{ fn.parameters | join(', ', attribute='x_decl') }}){%
         if fn.const %} const{% endif
-    %} override {
+    %}{{ fn.ref_qualifiers }} override {
+    {% if fn.data.trampoline_cpp_code %}
+    {{ fn.data.trampoline_cpp_code }}
+    {% else %}
     {# TODO: probably will break for things like out parameters, etc #}
     {% if fn.data.ignore_pure %}
         throw std::runtime_error("not implemented");
@@ -180,6 +183,7 @@ struct PyTrampoline_{{ cls.x_qualname_ }} : PyTrampolineBase, virtual py::trampo
         PYBIND11_OVERRIDE_IMPL(PYBIND11_TYPE({{ fn.rtnType }}), LookupBase,
             "{{ fn.x_name }}", {{ fn.parameters | join(', ', attribute='name') }});
         return CxxCallBase::{{ fn.name }}({{ fn.parameters | join(', ', attribute='x_virtual_callname') }});
+    {% endif %}
     {% endif %}
     {% endif %}
     }

--- a/robotpy_build/templates/pybind11.cpp.j2
+++ b/robotpy_build/templates/pybind11.cpp.j2
@@ -79,6 +79,7 @@
       {{- fn.x_in_params | join(', ', attribute='x_type_full') -}}
   )
   {%- if fn.const %} const{% endif -%}
+  {%- if fn.ref_qualifiers %} {{ fn.ref_qualifiers }}{% endif -%}
 {%- endmacro -%}
 
 {%- macro _genmethod(cls_qualname, fn, trampoline_qualname, tmpl) -%}
@@ -345,12 +346,12 @@
   {% if not cls.x_has_constructor and not cls.data.nodelete and not cls.data.force_no_default_constructor %}
     .def(py::init<>(), release_gil())
   {% endif -%}
-  {%- for fn in cls.methods.public if not fn.data.ignore and not fn.data.ignore_pure %}
+  {%- for fn in cls.methods.public if not fn.data.ignore and not fn.data.ignore_pure and not fn.data.ignore_py %}
     {{ genmethod(cls.x_qualname, fn, None) }}
   {% endfor -%}
 
   {%- if cls.x_has_trampoline -%}
-  {%- for fn in cls.methods.protected if not fn.data.ignore and not fn.data.ignore_pure %}
+  {%- for fn in cls.methods.protected if not fn.data.ignore and not fn.data.ignore_pure and not fn.data.ignore_py %}
     {{ genmethod(cls.x_qualname, fn, cls.x_trampoline_var) }}
   {% endfor -%}
   {%- endif -%}

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     setuptools >= 45
     setuptools_scm >= 6.2
     header2whatever >= 0.4.6
-    robotpy-cppheaderparser >= 5.0.18
+    robotpy-cppheaderparser >= 5.0.20
     sphinxify >= 0.7.3
     pydantic >= 1.7.0
     tomli

--- a/tests/cpp/gen/ft/refqual.yml
+++ b/tests/cpp/gen/ft/refqual.yml
@@ -1,0 +1,18 @@
+functions:
+  refquals_fn1:
+  refquals_fn2:
+classes:
+  RefQuals:
+    methods:
+      fn1:
+      fn2:
+        ignore_py: true
+        trampoline_cpp_code: |
+          // not useful, but shows we can specify whatever we want here
+          return 42;
+      fn3:
+        cpp_code: |
+          [](RefQuals *self) {
+            // not useful, but shows we can specify whatever we want here
+            return 43;
+          }

--- a/tests/cpp/pyproject.toml.tmpl
+++ b/tests/cpp/pyproject.toml.tmpl
@@ -58,6 +58,7 @@ generate = [
     { nested = "nested.h" },
     { overloads = "overloads.h" },
     { parameters = "parameters.h" },
+    { refqual = "refqual.h" },
     { rename = "rename.h" },
     { subpkg = "subpkg.h" },
     { static_only = "static_only.h" },

--- a/tests/cpp/rpytest/ft/include/refqual.h
+++ b/tests/cpp/rpytest/ft/include/refqual.h
@@ -1,0 +1,34 @@
+#pragma once
+
+struct RefQuals {
+
+    virtual ~RefQuals() {}
+
+    // pybind11 can bind this, but we have to specify the right
+    // ref-qualifier for the trampoline to compile
+    virtual int fn1() & {
+        return 1;
+    }
+
+    // pybind11 cannot bind this, have to do it manually
+    virtual int fn2() && {
+        return 2;
+    }
+
+    // pybind11 cannot bind this, have to do it manually
+    int fn3() && {
+        return 3;
+    }
+};
+
+int refquals_fn1(RefQuals &r) {
+    return r.fn1();
+}
+
+int refquals_fn2(RefQuals &r) {
+    return std::move(r).fn2();
+}
+
+int refquals_fn3(RefQuals &r) {
+    return std::move(r).fn3();
+}

--- a/tests/test_ft_refquals.py
+++ b/tests/test_ft_refquals.py
@@ -1,0 +1,30 @@
+import rpytest.ft._rpytest_ft as ft
+
+
+def test_refquals_ref():
+    r = ft.RefQuals()
+    assert ft.refquals_fn1(r) == 1
+
+
+def test_refquals_move1():
+    r = ft.RefQuals()
+    assert ft.refquals_fn2(r) == 2
+
+
+def test_refquals_move_custom():
+    class MyRefQuals(ft.RefQuals):
+        pass
+
+    r = MyRefQuals()
+    assert ft.refquals_fn2(r) == 42
+
+
+def test_refquals_move2():
+    r = ft.RefQuals()
+
+    # This calls our cpp_code override
+    assert r.fn3() == 43
+
+    # This still calls the C++ version since we can't override it
+    # merely with cpp_code
+    assert ft.refquals_fn3(r) == 3


### PR DESCRIPTION
- Correctly add & and && to trampoline definitions and function casts
- Provide ignore_py and trampoline_cpp_code