### PR TITLE
Add linux-armv7l as plain 32-bit ARM

### DIFF
--- a/robotpy_build/platforms.py
+++ b/robotpy_build/platforms.py
@@ -36,6 +36,7 @@ X86_64 = "x86-64"
 _platforms = {
     "linux-athena": WPILibMavenPlatform("athena", defines=["__FRC_ROBORIO__"]),
     "linux-raspbian": WPILibMavenPlatform("arm32", defines=["__RASPBIAN__"]),
+    "linux-armv7l": WPILibMavenPlatform("arm32"),
     "linux-x86_64": WPILibMavenPlatform(X86_64),
     "linux-aarch64": WPILibMavenPlatform("arm64"),
     "win32": WPILibMavenPlatform("x86", "windows", "", ".dll", ".lib", ".lib"),


### PR DESCRIPTION
Platforms like my ODROID-XU4 come in as "linux-armv7l". Treating this as plain "arm32", with no special DEFINE like for RPi, seems to work for me.