### PR TITLE
hippos

### DIFF
--- a/robotpy_build/tool.py
+++ b/robotpy_build/tool.py
@@ -147,10 +147,10 @@ class HeaderScanner:
                 files = set()
                 if wrapper.autogen_headers:
                     files |= {
-                        PurePosixPath(f) for f in wrapper.autogen_headers.values()
+                        Path(f) for f in wrapper.autogen_headers.values()
                     }
                 if wrapper.type_casters:
-                    files |= {PurePosixPath(tc.header) for tc in wrapper.type_casters}
+                    files |= {Path(tc.header) for tc in wrapper.type_casters}
                 if not files:
                     continue
                 for incdir in s.wrappers[i]._generation_search_path():
@@ -173,7 +173,7 @@ class HeaderScanner:
 
                 files = list(
                     sorted(
-                        PurePosixPath(relpath(f, incdir))
+                        Path(relpath(f, incdir))
                         for f in glob.glob(join(incdir, "**", "*.h"), recursive=True)
                         if "rpygen" not in f
                     )
@@ -195,7 +195,7 @@ class HeaderScanner:
                     lastdir = thisdir
 
                     base = f.stem
-                    print(f'{base} = "{f}"')
+                    print(f'{base} = "{f.as_posix()}"')
                 print()
 
 

--- a/robotpy_build/tool.py
+++ b/robotpy_build/tool.py
@@ -1,6 +1,7 @@
 import argparse
 import glob
 import inspect
+from itertools import chain
 from os.path import basename, dirname, exists, join, relpath
 from pathlib import Path, PurePosixPath
 import posixpath
@@ -172,7 +173,10 @@ class HeaderScanner:
                 files = list(
                     sorted(
                         Path(relpath(f, incdir))
-                        for f in glob.glob(join(incdir, "**", "*.h"), recursive=True)
+                        for f in chain(
+                            glob.glob(join(incdir, "**", "*.h"), recursive=True),
+                            glob.glob(join(incdir, "**", "*.hpp"), recursive=True),
+                        )
                         if "rpygen" not in f
                     )
                 )

--- a/robotpy_build/tool.py
+++ b/robotpy_build/tool.py
@@ -146,9 +146,7 @@ class HeaderScanner:
             for i, wrapper in enumerate(s.project.wrappers.values()):
                 files = set()
                 if wrapper.autogen_headers:
-                    files |= {
-                        Path(f) for f in wrapper.autogen_headers.values()
-                    }
+                    files |= {Path(f) for f in wrapper.autogen_headers.values()}
                 if wrapper.type_casters:
                     files |= {Path(tc.header) for tc in wrapper.type_casters}
                 if not files:


### PR DESCRIPTION
- Fix scan-headers on Windows
- black
- scan-headers: detect .hpp files
