### PR TITLE
Provide for Apple Silicon (ARM64) platform as well

### DIFF
--- a/robotpy_build/platforms.py
+++ b/robotpy_build/platforms.py
@@ -64,9 +64,11 @@ def get_platform(name: typing.Optional[str] = None) -> WPILibMavenPlatform:
         # Check for 64 bit x86 macOS (version agnostic)
         # - See https://github.com/pypa/setuptools/issues/2520 for universal2
         #   related questions? Sorta.
-        if re.fullmatch(r"macosx-.*-x86_64", pyplatform) or \
-            re.fullmatch(r"macosx-.*-arm64", pyplatform) or \
-            re.fullmatch(r"macosx-.*-universal2", pyplatform):
+        if (
+            re.fullmatch(r"macosx-.*-x86_64", pyplatform)
+            or re.fullmatch(r"macosx-.*-arm64", pyplatform)
+            or re.fullmatch(r"macosx-.*-universal2", pyplatform)
+        ):
             return _platforms["macos-universal"]
 
         if pyplatform == "linux-armv7l":

--- a/robotpy_build/platforms.py
+++ b/robotpy_build/platforms.py
@@ -64,9 +64,9 @@ def get_platform(name: typing.Optional[str] = None) -> WPILibMavenPlatform:
         # Check for 64 bit x86 macOS (version agnostic)
         # - See https://github.com/pypa/setuptools/issues/2520 for universal2
         #   related questions? Sorta.
-        if re.fullmatch(r"macosx-.*-x86_64", pyplatform) or re.fullmatch(
-            r"macosx-.*-universal2", pyplatform
-        ):
+        if re.fullmatch(r"macosx-.*-x86_64", pyplatform) or \
+            re.fullmatch(r"macosx-.*-arm64", pyplatform) or \
+            re.fullmatch(r"macosx-.*-universal2", pyplatform):
             return _platforms["macos-universal"]
 
         if pyplatform == "linux-armv7l":


### PR DESCRIPTION
This wheel fails to build on Apple Silicon (M1, M2, &c). This branch provides for it.

Not sure about provisioning arm64 test runners in the GitHub workflows.