### PR TITLE
Ensure template classes are instantiated in correct order

### DIFF
--- a/robotpy_build/autowrap/header.cpp.j2
+++ b/robotpy_build/autowrap/header.cpp.j2
@@ -64,13 +64,19 @@ struct rpybuild_{{ hname }}_initializer {
 {% endfor %}
 
 {# template decls #}
-{% for tmpl_data in template_instances %}
+{% for tmpl_data in template_instances if not tmpl_data.matched %}
   rpygen::{{ tmpl_data.binder_typename }} {{ tmpl_data.var_name }};
 {% endfor %}
 
 {# class decls #}
-{%- for cls in classes if not cls.template %}
-  {{ pybind11.cls_decl(cls) }}
+{%- for cls in classes %}
+  {% if not cls.template -%}
+    {{ pybind11.cls_decl(cls) }}
+  {%- else -%}
+    {%- for tmpl_data in cls.template.instances %}
+      rpygen::{{ tmpl_data.binder_typename }} {{ tmpl_data.var_name }};
+    {% endfor -%}
+  {%- endif -%}
 {% endfor %}
 
   py::module &m;
@@ -86,12 +92,18 @@ struct rpybuild_{{ hname }}_initializer {
     enum{{ loop.index }}{{ pybind11.enum_init(enum.scope_var, enum) }},
   {% endfor %}
 
-  {% for tmpl_data in template_instances %}
+  {% for tmpl_data in template_instances if not tmpl_data.matched %}
     {{ tmpl_data.var_name }}({{ tmpl_data.scope_var }}, "{{ tmpl_data.py_name }}"),
   {% endfor %}
 
-  {% for cls in classes if not cls.template %}
-    {{ pybind11.cls_init(cls, '"' + cls.py_name + '"') }}
+  {% for cls in classes %}
+    {% if not cls.template -%}
+      {{ pybind11.cls_init(cls, '"' + cls.py_name + '"') }}
+    {%- else -%}
+      {%- for tmpl_data in cls.template.instances %}
+        {{ tmpl_data.var_name }}({{ tmpl_data.scope_var }}, "{{ tmpl_data.py_name }}"),
+      {% endfor -%}
+    {%- endif %}
   {% endfor %}
 
     m(m)

--- a/robotpy_build/autowrap/j2_context.py
+++ b/robotpy_build/autowrap/j2_context.py
@@ -353,6 +353,9 @@ class ClassTemplateData:
     #: the specified C++ code is inserted into the template definition
     inline_code: str
 
+    #: Instances of this class
+    instances: typing.List["TemplateInstanceContext"] = field(default_factory=list)
+
 
 @dataclass
 class ClassContext:
@@ -492,6 +495,9 @@ class TemplateInstanceContext:
 
     doc_set: Documentation
     doc_add: Documentation
+
+    #: If true, instantiated in class order
+    matched: bool = False
 
 
 @dataclass

--- a/tests/cpp/gen/ft/tdependent_base.yml
+++ b/tests/cpp/gen/ft/tdependent_base.yml
@@ -1,0 +1,11 @@
+classes:
+  TDBase:
+  TDChild:
+    template_params:
+    - T
+
+templates:
+  TDChild:
+    qualname: TDChild
+    params:
+    - int

--- a/tests/cpp/pyproject.toml.tmpl
+++ b/tests/cpp/pyproject.toml.tmpl
@@ -101,6 +101,7 @@ generate = [
     {tvchild = "templates/tvchild.h"},
 
     {tbasic = "templates/basic.h"},
+    {tdependent_base = "templates/dependent_base.h"},
     {tdependent_param = "templates/dependent_param.h"},
     {tdependent_using = "templates/dependent_using.h"},
     {tdependent_using2 = "templates/dependent_using2.h"},

--- a/tests/cpp/rpytest/ft/include/templates/dependent_base.h
+++ b/tests/cpp/rpytest/ft/include/templates/dependent_base.h
@@ -1,0 +1,10 @@
+#pragma once
+
+// Template class that has a non-template base class in the same file
+
+struct TDBase  {
+    virtual ~TDBase() {}
+};
+
+template <typename T>
+struct TDChild : TDBase {};


### PR DESCRIPTION
- If it depends on a base class, the base needs to be initialized first
- Not all template classes exist in the header (in particular, CRTP) so anything not found in the current header gets initialized first