### PR TITLE
Update pybind11-stubgen to 2.5.x

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -89,7 +89,7 @@ jobs:
     strategy:
       max-parallel: ${{ fromJSON(needs.setup_concurrency.outputs.max-parallel).v }}
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-20.04]
+        os: ["ubuntu-22.04", "macos-12", "windows-2022"]
         python_version:
         - '3.8'
         - '3.9'
@@ -98,9 +98,9 @@ jobs:
         - '3.12'
         architecture: [x86, x64]
         exclude:
-        - os: macos-latest
+        - os: macos-12
           architecture: x86
-        - os: ubuntu-20.04
+        - os: ubuntu-22.04
           architecture: x86
 
     steps:

--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -119,21 +119,11 @@ jobs:
         name: dist
         path: dist
 
-    - name: Set ccache variant
-      shell: bash
-      id: ccache
-      run: |
-        if [[ "${{ matrix.os }}" == windows-* ]]; then
-          echo "VARIANT=sccache" >> $GITHUB_OUTPUT
-        else
-          echo "VARIANT=ccache" >> $GITHUB_OUTPUT
-        fi
-
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: robotpy/ccache-action@fork
       with:
           key: ${{ matrix.os }}-${{ matrix.architecture }}-${{ matrix.python_version }}
-          variant: ${{ steps.ccache.outputs.variant }}
+          variant: ccache
 
     - name: Install
       shell: bash
@@ -150,7 +140,7 @@ jobs:
       env:
         RPYBUILD_PARALLEL: 1
         RPYBUILD_STRIP_LIBPYTHON: 1
-        RPYBUILD_CC_LAUNCHER: ${{ steps.ccache.outputs.variant }}
+        RPYBUILD_CC_LAUNCHER: ccache
       working-directory: tests
       run: |
         python run_tests.py
@@ -176,7 +166,7 @@ jobs:
 
     - run: apt-get update
     - name: Setup ccache
-      uses: hendrikmuhs/ccache-action@v1.2
+      uses: robotpy/ccache-action@fork
       with:
           key: ${{ matrix.container }}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,5 +9,4 @@ write_to = "robotpy_build/version.py"
 target-version = ['py38']
 extend-exclude = '''
 ^/robotpy_build/pybind11
-^/robotpy_build/version.py
 '''

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ install_requires =
     typing-extensions
     pyyaml >= 5.1
     patch == 1.*
-    pybind11-stubgen ~= 2.3.3
+    pybind11-stubgen ~= 2.5.1
     delocate; platform_system == 'Darwin'
     distro; platform_system == 'Linux'
 python_requires = >=3.8


### PR DESCRIPTION
<details>
<summary>Changes since 2.3.x</summary>

Version 2.5.1 (Mar 26, 2024)
--------------------------
Changes:
- 🐛 Fixed: Missed numpy unsigned int types

Version 2.5 (Mar 3, 2024)
--------------------------
Changes:
- 🐛 Fixed: Don't render pybind11 `KeysView`, `ValuesView`, `ItemsView` class definitions
- 🐛 Fixed: Escape backslashes in stub output

Version 2.4.1 (Nov 25, 2023)
--------------------------
Changes:
- 🐛 Fixed: do not remove `self` parameter annotation when types do not match

Version 2.4 (Nov 21, 2023)
--------------------------
Changes:
- ✨ Added `--numpy-array-use-type-var` flag which reformats the pybind11-generated `numpy.ndarray[numpy.float32[m, 1]]` annotation as `numpy.ndarray[tuple[M, Literal[1]], numpy.dtype[numpy.float32]]`

</details>