### PR TITLE
Put trampolines in original class namespace

### DIFF
--- a/robotpy_build/autowrap/context.py
+++ b/robotpy_build/autowrap/context.py
@@ -287,6 +287,12 @@ class BaseClassData:
     Render data for each base that a class inherits
     """
 
+    #: Just the class name
+    cls_name: str
+
+    #: This ends with ::
+    namespace_: str
+
     #: C++ name, including all known components
     full_cpp_name: str  # was x_qualname
 
@@ -295,9 +301,6 @@ class BaseClassData:
     #: Translated C++ name suitable for use as an identifier. :<>= are
     #: turned into underscores.
     full_cpp_name_identifier: str  # was x_qualname_
-
-    #: This ends with ::
-    namespace_: str
 
     #: C++ name + components, no template parameters
     dep_cpp_name: str

--- a/robotpy_build/autowrap/context.py
+++ b/robotpy_build/autowrap/context.py
@@ -296,6 +296,9 @@ class BaseClassData:
     #: turned into underscores.
     full_cpp_name_identifier: str  # was x_qualname_
 
+    #: This ends with ::
+    namespace_: str
+
     #: C++ name + components, no template parameters
     dep_cpp_name: str
 

--- a/robotpy_build/autowrap/render_cls_rpy_include.py
+++ b/robotpy_build/autowrap/render_cls_rpy_include.py
@@ -124,12 +124,12 @@ def _render_cls_trampoline(
     )
 
     if cls.bases:
-        r.writeln(f"struct PyTrampolineCfg_{cls.full_cpp_name_identifier} :")
+        r.writeln(f"struct PyTrampolineCfg_{cls.cpp_name} :")
 
         with r.indent():
             for base in cls.bases:
                 r.writeln(
-                    f"{base.namespace_}PyTrampolineCfg_{base.full_cpp_name_identifier}<{postcomma(base.template_params)}"
+                    f"{base.namespace_}PyTrampolineCfg_{base.cls_name}<{postcomma(base.template_params)}"
                 )
 
             r.writeln("CfgBase")
@@ -137,7 +137,7 @@ def _render_cls_trampoline(
             for base in cls.bases:
                 r.writeln(">")
     else:
-        r.writeln(f"struct PyTrampolineCfg_{cls.full_cpp_name_identifier} : CfgBase")
+        r.writeln(f"struct PyTrampolineCfg_{cls.cpp_name} : CfgBase")
 
     r.writeln("{")
 
@@ -162,11 +162,11 @@ def _render_cls_trampoline(
         r.writeln(
             f"template <typename PyTrampolineBase{precomma(template_parameter_list)}, typename PyTrampolineCfg>"
         )
-        r.writeln(f"using PyTrampolineBase_{cls.full_cpp_name_identifier} =")
+        r.writeln(f"using PyTrampolineBase_{cls.cpp_name} =")
 
         for base in cls.bases:
             r.rel_indent(2)
-            r.writeln(f"{base.namespace_}PyTrampoline_{base.full_cpp_name_identifier}<")
+            r.writeln(f"{base.namespace_}PyTrampoline_{base.cls_name}<")
 
         with r.indent():
             r.writeln("PyTrampolineBase")
@@ -182,8 +182,8 @@ def _render_cls_trampoline(
             ;
 
             template <typename PyTrampolineBase{ precomma(template_parameter_list) }, typename PyTrampolineCfg>
-            struct PyTrampoline_{ cls.full_cpp_name_identifier } : PyTrampolineBase_{ cls.full_cpp_name_identifier }<PyTrampolineBase{ precomma(template_argument_list) }, PyTrampolineCfg> {{
-              using PyTrampolineBase_{ cls.full_cpp_name_identifier }<PyTrampolineBase{ precomma(template_argument_list) }, PyTrampolineCfg>::PyTrampolineBase_{ cls.full_cpp_name_identifier };
+            struct PyTrampoline_{ cls.cpp_name } : PyTrampolineBase_{ cls.cpp_name }<PyTrampolineBase{ precomma(template_argument_list) }, PyTrampolineCfg> {{
+              using PyTrampolineBase_{ cls.cpp_name }<PyTrampolineBase{ precomma(template_argument_list) }, PyTrampolineCfg>::PyTrampolineBase_{ cls.cpp_name };
         """
         )
 
@@ -192,7 +192,7 @@ def _render_cls_trampoline(
         r.write_trim(
             f"""
             template <typename PyTrampolineBase{ precomma(template_parameter_list) }, typename PyTrampolineCfg>
-            struct PyTrampoline_{ cls.full_cpp_name_identifier } : PyTrampolineBase {{
+            struct PyTrampoline_{ cls.cpp_name } : PyTrampolineBase {{
               using PyTrampolineBase::PyTrampolineBase;
         """
         )
@@ -232,11 +232,11 @@ def _render_cls_trampoline(
             with r.indent():
                 all_decls = ", ".join(p.decl for p in fn.all_params)
                 all_names = ", ".join(p.arg_name for p in fn.all_params)
-                r.writeln(f"PyTrampoline_{cls.full_cpp_name_identifier}({all_decls}) :")
+                r.writeln(f"PyTrampoline_{cls.cpp_name}({all_decls}) :")
 
                 if cls.bases:
                     r.writeln(
-                        f"  PyTrampolineBase_{cls.full_cpp_name_identifier}<PyTrampolineBase{precomma(trampoline.tmpl_args)}, PyTrampolineCfg>({all_names})"
+                        f"  PyTrampolineBase_{cls.cpp_name}<PyTrampolineBase{precomma(trampoline.tmpl_args)}, PyTrampolineCfg>({all_names})"
                     )
                 else:
                     r.writeln(f"  PyTrampolineBase({all_names})")

--- a/robotpy_build/autowrap/render_cls_rpy_include.py
+++ b/robotpy_build/autowrap/render_cls_rpy_include.py
@@ -101,10 +101,8 @@ def _render_cls_trampoline(
         for base in cls.bases:
             r.writeln(f"#include <rpygen/{ base.full_cpp_name_identifier }.hpp>")
 
-    r.writeln("\nnamespace rpygen {")
-
     if cls.namespace:
-        r.writeln(f"\nusing namespace {cls.namespace};")
+        r.writeln(f"\nnamespace {cls.namespace.strip('::')} {{")
 
     if hctx.using_declarations:
         r.writeln()
@@ -122,7 +120,7 @@ def _render_cls_trampoline(
     #
 
     r.writeln(
-        f"\ntemplate <{postcomma(template_parameter_list)}typename CfgBase = EmptyTrampolineCfg>"
+        f"\ntemplate <{postcomma(template_parameter_list)}typename CfgBase = rpygen::EmptyTrampolineCfg>"
     )
 
     if cls.bases:
@@ -131,7 +129,7 @@ def _render_cls_trampoline(
         with r.indent():
             for base in cls.bases:
                 r.writeln(
-                    f"PyTrampolineCfg_{base.full_cpp_name_identifier}<{postcomma(base.template_params)}"
+                    f"{base.namespace_}PyTrampolineCfg_{base.full_cpp_name_identifier}<{postcomma(base.template_params)}"
                 )
 
             r.writeln("CfgBase")
@@ -168,7 +166,7 @@ def _render_cls_trampoline(
 
         for base in cls.bases:
             r.rel_indent(2)
-            r.writeln(f"PyTrampoline_{base.full_cpp_name_identifier}<")
+            r.writeln(f"{base.namespace_}PyTrampoline_{base.full_cpp_name_identifier}<")
 
         with r.indent():
             r.writeln("PyTrampolineBase")
@@ -284,7 +282,10 @@ def _render_cls_trampoline(
             r.writeln()
             r.write_trim(trampoline.inline_code)
 
-    r.writeln("};\n\n}; // namespace rpygen")
+    r.writeln("};\n\n")
+
+    if cls.namespace:
+        r.writeln(f"}}; // namespace {cls.namespace}")
 
 
 def _render_cls_trampoline_virtual_method(

--- a/tests/cpp/pyproject.toml.tmpl
+++ b/tests/cpp/pyproject.toml.tmpl
@@ -61,6 +61,7 @@ generate = [
     { lifetime = "lifetime.h" },
     { nested = "nested.h" },
     { ns_class = "ns_class.h" },
+    { ns_hidden = "ns_hidden.h" },
     { operators = "operators.h" },
     { overloads = "overloads.h" },
     { parameters = "parameters.h" },

--- a/tests/cpp/rpytest/ft/include/ns_hidden.h
+++ b/tests/cpp/rpytest/ft/include/ns_hidden.h
@@ -1,0 +1,31 @@
+#pragma once
+
+namespace n {
+    enum class E {
+        Item,
+    };
+};
+
+namespace o {
+    struct O {
+        O() = default;
+        virtual ~O() = default;
+    };
+
+    class AnotherC;
+};
+
+namespace n::h {
+    class C : public o::O {
+    public:
+        // E is resolved here because it's in the parent namespace but our
+        // trampoline was originally in a different namespace and failed
+        virtual E fn() { return E::Item; }
+    };
+};
+
+struct o::AnotherC {
+    AnotherC() = default;
+    virtual ~AnotherC() = default;
+    virtual int fn() { return 1; }
+};


### PR DESCRIPTION
- This simplifies wrapping somewhat and avoids compile errors when the trampoline references a class in a parent namespace
- This is a breaking change -- bindings need to be recompiled to match each other