### PR TITLE
Allow renaming constructor overloads to static methods

### DIFF
--- a/robotpy_build/autowrap/cxxparser.py
+++ b/robotpy_build/autowrap/cxxparser.py
@@ -1072,6 +1072,9 @@ class AutowrapVisitor:
 
         # Update class-specific method attributes
         fctx.is_constructor = is_constructor
+        if is_constructor and method_data.rename and not method_data.cpp_code:
+            fctx.cpp_return_type = cctx.full_cpp_name
+            self._on_fn_make_lambda(method_data, fctx)
         if operator:
             fctx.operator = operator
             self.hctx.need_operators_h = True
@@ -1581,6 +1584,7 @@ class AutowrapVisitor:
 
         * When an 'out' parameter is detected (a pointer receiving a value)
         * When a buffer + size parameter exists (either in or out)
+        * When "renaming" a constructor overload to a static method
         """
 
         # Statements to insert before calling the function

--- a/robotpy_build/config/autowrap_yml.py
+++ b/robotpy_build/config/autowrap_yml.py
@@ -145,6 +145,8 @@ class FunctionData(Model):
     internal: bool = False
 
     #: Use this to set the name of the function as exposed to python
+    #:
+    #: When applied to a constructor, creates a static method for the overload instead.
     rename: Optional[str] = None
 
     #: Mechanism to override individual parameters
@@ -212,7 +214,7 @@ class FunctionData(Model):
     def validate_virtual_xform(cls, v, values):
         if v and values.get("trampoline_cpp_code"):
             raise ValueError(
-                f"cannot specify trampoline_cpp_code and virtual_xform for the same method"
+                "cannot specify trampoline_cpp_code and virtual_xform for the same method"
             )
         return v
 
@@ -222,6 +224,8 @@ if not _generating_documentation:
 
 
 class PropAccess(enum.Enum):
+    """Whether a property is writable."""
+
     #: Determine read/read-write automatically:
     #:
     #: * If a struct/union, default to readwrite

--- a/tests/cpp/gen/ft/rename.yml
+++ b/tests/cpp/gen/ft/rename.yml
@@ -26,6 +26,11 @@ classes:
           Param1:
             rename: P1
     methods:
+      OriginalClass:
+        overloads:
+          '':
+          int:
+            rename: new
       fnOriginal:
         rename: fnRenamed
       fnRenamedParam:

--- a/tests/cpp/rpytest/ft/include/rename.h
+++ b/tests/cpp/rpytest/ft/include/rename.h
@@ -12,6 +12,9 @@ int fnRenamedParam(int x) { return x; }
 
 // class
 struct OriginalClass {
+    // constructor
+    OriginalClass() = default;
+    explicit OriginalClass(int prop) : originalProp(prop) {};
 
     // class function
     int fnOriginal() { return 0x2; }

--- a/tests/test_ft_rename.py
+++ b/tests/test_ft_rename.py
@@ -30,6 +30,10 @@ def test_rename_cls():
     assert not hasattr(c.ClassRenamedEnum, "Param1")
     assert c.ClassRenamedEnum.P1 == 1
 
+    n = ft.RenamedClass.new(1)
+    assert isinstance(n, ft.RenamedClass)
+    assert n.renamedProp == 1
+
 
 def test_rename_enums():
     assert not hasattr(ft._rpytest_ft, "OriginalEnum")


### PR DESCRIPTION
Occasionally we want to expose a C++ constructor overload as a static method rather than an overload.