### PR TITLE
Allow disabling keepalive inference for constructors

### DIFF
--- a/robotpy_build/autowrap/cxxparser.py
+++ b/robotpy_build/autowrap/cxxparser.py
@@ -1105,7 +1105,7 @@ class AutowrapVisitor:
 
         # automatically retain references passed to constructors if the
         # user didn't specify their own keepalive
-        if is_constructor and not method_data.keepalive:
+        if is_constructor and method_data.keepalive is None:
             for i, pctx in enumerate(fctx.filtered_params):
                 if pctx.full_cpp_type.endswith("&"):
                     fctx.keepalives.append((1, i + 2))


### PR DESCRIPTION
Sometimes we don't actually need keepalives for references passed to constructors. For example, none of [Rotation3d]'s const-ref-taking constructor overloads hold the references in the instance.

Allow an explicit empty list to disable the constructor reference keepalive inference.

[Rotation3d]: https://github.com/wpilibsuite/allwpilib/blob/d4985b8ba062eec75f76dd8e40acb1282d2dc6c4/wpimath/src/main/native/include/frc/geometry/Rotation3d.h#L41