### PR TITLE
ci: Move black to pre-commit

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: psf/black@stable
+    - uses: pre-commit/action@v3.0.1
   
   check-doc:
     runs-on: ubuntu-20.04

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+---
+repos:
+  - repo: https://github.com/psf/black-pre-commit-mirror
+    rev: 24.10.0
+    hooks:
+      - id: black


### PR DESCRIPTION
This intends to do two things:

1. Pin the black version, so we don't get surprised by the annual black major release suddenly failing CI.
2. Make it easier for first-time contributors to discover the formatters/linters we have, and make these checks easier to reproduce locally (e.g. `pre-commit run --all-files`).

Once this is in we can move the pre-commit job off of GitHub Actions (to avoid hitting concurrent runner limits) by using https://pre-commit.ci instead (which will also provide autoupdate PRs and autofixing).