### PR TITLE
Upgrade to pybind11 v3 prerelease

### DIFF
--- a/robotpy_build/autowrap/render_pybind11.py
+++ b/robotpy_build/autowrap/render_pybind11.py
@@ -338,6 +338,8 @@ def cls_decl(r: RenderBuffer, cls: ClassContext):
         class_params.append(
             f"std::unique_ptr<typename {cls.full_cpp_name}, py::nodelete>"
         )
+    else:
+        class_params.append("py::smart_holder")
 
     if cls.trampoline:
         class_params.append(cls.trampoline.var)

--- a/robotpy_build/command/build_ext.py
+++ b/robotpy_build/command/build_ext.py
@@ -134,7 +134,6 @@ class BuildExt(build_ext):
                 self.compiler._rpy_spawn = self.compiler.spawn
                 self.compiler.spawn = _spawn
         for ext in self.extensions:
-            ext.define_macros.append(("PYBIND11_USE_SMART_HOLDER_AS_DEFAULT", "1"))
             if debug:
                 ext.define_macros.append(
                     ("PYBIND11_ASSERT_GIL_HELD_INCREF_DECREF", "1")

--- a/tests/test_ft_docs.py
+++ b/tests/test_ft_docs.py
@@ -39,7 +39,7 @@ def test_docstrings_meth():
 def test_docstrings_meth_kwd():
     assert inspect.getdoc(ft.DocClass.fn2) == inspect.cleandoc(
         """
-        fn2(self: rpytest.ft._rpytest_ft.DocClass, from_: int) -> None
+        fn2(self: rpytest.ft._rpytest_ft.DocClass, from_: typing.SupportsInt) -> None
         
         Function with parameter that's a python keyword
 
@@ -51,7 +51,7 @@ def test_docstrings_meth_kwd():
 def test_docstrings_meth_rename():
     assert inspect.getdoc(ft.DocClass.fn3) == inspect.cleandoc(
         """
-        fn3(self: rpytest.ft._rpytest_ft.DocClass, ohai: int) -> None
+        fn3(self: rpytest.ft._rpytest_ft.DocClass, ohai: typing.SupportsInt) -> None
         
         Function with renamed parameter
 


### PR DESCRIPTION
- This is a breaking change, but it's worth it, and nobody uses robotpy-build anyways