### PR TITLE
ci: Remove aarch64 cross-build

### DIFF
--- a/.github/workflows/dist.yml
+++ b/.github/workflows/dist.yml
@@ -162,7 +162,6 @@ jobs:
         container:
         - wpilib/roborio-cross-ubuntu:2024-22.04-py312
         - wpilib/raspbian-cross-ubuntu:bullseye-22.04-py312
-        - wpilib/aarch64-cross-ubuntu:bullseye-22.04-py312
 
     container:
       image: "${{ matrix.container }}"


### PR DESCRIPTION
The aarch64 cross-build image is no longer used downstream.