### PR TITLE
Multiple Dependency Libraries

### DIFF
--- a/robotpy_build/wrapper.py
+++ b/robotpy_build/wrapper.py
@@ -419,7 +419,7 @@ class Wrapper:
             if dl.libs or dl.dlopenlibs:
                 add_libdir = True
                 extract_names = []
-                os.makedirs(libdir)
+                os.makedirs(libdir, exist_ok=True)
 
                 libext = dl.libexts.get(self.platform.libext, self.platform.libext)
                 linkext = dl.linkexts.get(self.platform.linkext, self.platform.linkext)


### PR DESCRIPTION
If multiple downloads are specified in the pyproject.yaml (e.g. [[tool.robotpy-build.wrappers."<package name>".download]] is repeated), the first one will create the lib directory where the download's libraries will be extracted to. However, the second will fail because the lib directory already exists. I just modified this to add exist_ok to the os.makedirs call so the second (and third, etc.) can add their libraries as well.