### PR TITLE
Library linking order

### DIFF
--- a/robotpy_build/wrapper.py
+++ b/robotpy_build/wrapper.py
@@ -310,12 +310,17 @@ class Wrapper:
         libs = list(
             set(self.get_library_names()) | set(self.get_dlopen_library_names())
         )
+        libs = []
+        [libs.append(lib) for lib in self.get_library_names() if lib not in libs]
+        [libs.append(lib) for lib in self.get_dlopen_library_names() if lib not in libs]
+        dep_libs = []
         for dep in self.cfg.depends:
             pkg = self.pkgcfg.get_pkg(dep)
             libnames = pkg.get_library_names()
             if libnames:
-                libs.extend(libnames)
-        return list(reversed(libs))
+                [dep_libs.append(lib) for lib in libnames if lib not in libs]
+        libs.extend(reversed(dep_libs))
+        return libs
 
     def _all_extra_objects(self):
         libs = []

--- a/robotpy_build/wrapper.py
+++ b/robotpy_build/wrapper.py
@@ -307,9 +307,6 @@ class Wrapper:
         return libs
 
     def _all_library_names(self):
-        libs = list(
-            set(self.get_library_names()) | set(self.get_dlopen_library_names())
-        )
         libs = []
         [libs.append(lib) for lib in self.get_library_names() if lib not in libs]
         [libs.append(lib) for lib in self.get_dlopen_library_names() if lib not in libs]


### PR DESCRIPTION
Previously the list of libraries gathered started with the libraries included in the package, then the dependency libraries were gathered. This list was finally reversed before being returned.

This causes an issue where the libraries included in the package are listed last when linking the final shared library and all of the dependencies are listed before that. Because of this, the symbols in the package libraries are not resolved.

I have modified it so that the package libraries are added to the list, then the dependencies, in reverse order, are added to the list.

P.S. - I know that you've migrated to semiwrap, and I intend to do this as well. But I was several libraries in when that migration started, so I decided to finish the robotpy-build wrapping first before migrating!